### PR TITLE
fix: do not raise on schema/data with string keys

### DIFF
--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -300,7 +300,7 @@ defmodule Peri do
   end
 
   defp enumerable_has_key?(data, key) when is_map(data) do
-    Map.has_key?(data, key) or Map.has_key?(data, Atom.to_string(key))
+    Map.has_key?(data, key) or Map.has_key?(data, (is_binary(key) && key) || Atom.to_string(key))
   end
 
   defp enumerable_has_key?(data, key) when is_list(data) do
@@ -334,7 +334,7 @@ defmodule Peri do
 
   defp get_enumerable_value(enum, key) do
     case Access.get(enum, key) do
-      nil when is_map(enum) -> Map.get(enum, Atom.to_string(key))
+      nil when is_map(enum) -> Map.get(enum, (is_binary(key) && key) || Atom.to_string(key))
       val -> val
     end
   end

--- a/test/peri_test.exs
+++ b/test/peri_test.exs
@@ -9,6 +9,12 @@ defmodule PeriTest do
     email: {:required, :string}
   })
 
+  defschema(:simple_mixed_keys, %{
+    "email" => {:required, :string},
+    name: :string,
+    age: :integer
+  })
+
   defschema(:nested, %{
     user: %{
       name: :string,
@@ -67,6 +73,13 @@ defmodule PeriTest do
                ]
              } =
                simple(data)
+    end
+
+    test "does not raise on simple schema with string keys" do
+      data = %{name: "John", age: 30}
+
+      assert {:error, [%Peri.Error{path: ["email"], message: "is required"}]} =
+               simple_mixed_keys(data)
     end
   end
 


### PR DESCRIPTION
Allow binary keys when traversing data. Unsure if this is the correct fix.

**Type of Change**
- [x] Bug fix

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

Example:
```
iex|29| schema = %{"str" => {:required, :string, {:transform, &String.trim/1}}}
%{"str" => {:required, {:string, {:transform, &String.trim/1}}}}
iex|30| Peri.validate(schema, %{"str" => "aaaaaaa "})
{:ok, %{"str" => "aaaaaaa"}}
iex|31| Peri.validate(schema, %{"a" => "aaaaaaa "})
..!!** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not an atom

    (erts 14.2.2) :erlang.atom_to_binary("str")
    (peri 0.2.6) lib/peri.ex:358: Peri.get_enumerable_value/2
    (peri 0.2.6) lib/peri.ex:302: anonymous fn/3 in Peri.filter_data/2
    (stdlib 5.2) maps.erl:416: :maps.fold_1/4
    (peri 0.2.6) lib/peri.ex:300: Peri.filter_data/2
    (peri 0.2.6) lib/peri.ex:275: Peri.validate/2
    iex:31: (file)
iex|32|Peri.validate(schema, %{"str" => 123})
{:error,
 [
   %Peri.Error{
     path: ["str"],
     key: "str",
     content: %{actual: "123", expected: :string},
     message: "expected type of :string received 123 value",
     errors: nil
   }
 ]}
 ```
