### PR TITLE
Allow structs to be used as data

### DIFF
--- a/lib/peri/parser.ex
+++ b/lib/peri/parser.ex
@@ -44,7 +44,7 @@ defmodule Peri.Parser do
       %Peri.Parser{data: %{name: "Alice", age: 30}, errors: [], path: []}
   """
   def update_data(%__MODULE__{} = state, key, val) do
-    %{state | data: put_in(state.data[key], val).data}
+    %{state | data: Peri.put_in_enum(state.data, key, val)}
   end
 
   @doc """

--- a/test/peri_test.exs
+++ b/test/peri_test.exs
@@ -1877,4 +1877,40 @@ defmodule PeriTest do
              ] = errors
     end
   end
+
+  defmodule User do
+    defstruct [:name, :age, :email]
+  end
+
+  defschema(:user_map_schema, %{
+    name: {:required, :string},
+    age: :integer,
+    email: {:required, :string}
+  })
+
+  describe "basic struct input validation" do
+    test "validates struct input with valid data" do
+      data = %User{name: "John", age: 30, email: "john@example.com"}
+      assert {:ok, ^data} = user_map_schema(data)
+    end
+
+    test "validates struct input with missing required field" do
+      data = %User{name: "John", age: 30}
+
+      assert {:error, [%Peri.Error{path: [:email], message: "is required"}]} =
+               user_map_schema(data)
+    end
+
+    test "validates struct input with invalid field type" do
+      data = %User{name: "John", age: "thirty", email: "john@example.com"}
+
+      assert {:error,
+              [
+                %Peri.Error{
+                  path: [:age],
+                  message: "expected type of :integer received \"thirty\" value"
+                }
+              ]} = user_map_schema(data)
+    end
+  end
 end


### PR DESCRIPTION
**Description**
Handle struct to be used as data. Although peri doesn't support struct as schema definition yet, it
makes sense to define schemas for structs while passing the struct as data to be validated.

**Related Issues**
This solves #6.

**Type of Change**
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
N/A
