### PR TITLE
Avoid fetching Peri.Parser on raw data schemas

### DIFF
--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -527,7 +527,9 @@ defmodule Peri do
   end
 
   defp validate_field(val, {:cond, condition, true_type, else_type}, parser) do
-    if condition.(parser.root_data) do
+    root = maybe_get_root_data(parser)
+
+    if condition.(root) do
       validate_field(val, true_type, parser)
     else
       validate_field(val, else_type, parser)
@@ -536,7 +538,9 @@ defmodule Peri do
 
   defp validate_field(val, {:dependent, callback}, parser)
        when is_function(callback, 1) do
-    with {:ok, type} <- callback.(parser.root_data),
+    root = maybe_get_root_data(parser)
+
+    with {:ok, type} <- callback.(root),
          {:ok, schema} <- validate_schema(type) do
       validate_field(val, schema, parser)
     end
@@ -669,7 +673,7 @@ defmodule Peri do
   end
 
   defp validate_field(data, schema, p) when is_enumerable(data) do
-    root = p.root_data
+    root = maybe_get_root_data(p)
 
     case traverse_schema(schema, Peri.Parser.new(data, root_data: root)) do
       %Peri.Parser{errors: []} = parser -> {:ok, parser.data}
@@ -681,6 +685,10 @@ defmodule Peri do
     info = [expected: type, actual: inspect(val, pretty: true)]
     {:error, "expected type of %{expected} received %{actual} value", info}
   end
+
+  # if schema is matches a raw data structure, it will not use the Peri.Parser
+  defp maybe_get_root_data(%Peri.Parser{} = p), do: p.root_data
+  defp maybe_get_root_data(data), do: data
 
   @doc """
   Validates a schema definition to ensure it adheres to the expected structure and types.


### PR DESCRIPTION
**Description**
When defining raw data structures schemas like `{:list, schema}`, internally the schema validator
doesn't use the `Peri.Parser`, as it is designed to handle nested structres recursively.

So we provide the "root data" as the raw data as it is.

**Related Issues**
This closes #7.

**Type of Change**
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
Add any other context or screenshots about the pull request here.
