### PR TITLE
Access data fields on transformation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ end
 - `{type, {:default, default}}` - Provides a default value if the field is missing or `nil`.
   - `{type, {:default, &some_fun/0}}` - The default values is retrieved from callinf `some_fun/0` if the field is missing.
   - `{type, {:default, {mod, fun}}}` - The default values is retrieved from callinf `mod.fun/0` if the field is missing.
-- `{type, {:transform, mapper}}` - Transforms the field value using the specified mapper function.
-  - `{type, {:transform, {mod, fun}}}` - Transforms the field value using the specified `mod.fun/1` function.
+- `{type, {:transform, mapper}}` - Transforms the field value using the specified mapper function. It can be a 1 or 2 arity function: when is a single arity the mapper function will only receive the defined field value, while with 2 arity will receive the current defined field value and the whole data as the second argument.
+  - `{type, {:transform, {mod, fun}}}` - Transforms the field value using the specified `mod.fun/1` function. Notice that `fun` can be a 2 arity so it can receive the whole data being validated, in case on dependent fields transformations.
+  - `{type, {:transform, {mod, fun, args}}}` - Transforms the field value using the specified MFA. Notice that `fun` will be at least a 2 arity one so it can receive the whole data being validated, in case on dependent fields transformations and the maximum arity allowed will be 2 + `length(args)`.
 - `{:either, {type1, type2}}` - Validates that the field is either of the two specified types.
 - `{:oneof, types}` - Validates that the field is one of the specified types.
 - `{:custom, callback}` - Validates that the field passes the custom validation function.

--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -675,14 +675,34 @@ defmodule Peri do
   defp validate_field(val, {type, {:transform, {mod, fun}}}, data)
        when is_atom(mod) and is_atom(fun) do
     with :ok <- validate_field(val, type, data) do
-      {:ok, apply(mod, fun, [val])}
+      cond do
+        function_exported?(mod, fun, 1) ->
+          {:ok, apply(mod, fun, [val])}
+
+        function_exported?(mod, fun, 2) ->
+          {:ok, apply(mod, fun, [val, maybe_get_root_data(data)])}
+
+        true ->
+          template = "expected %{mod} to export %{fun}/1 or %{fun}/2"
+          {:error, template, mod: mod, fun: fun}
+      end
     end
   end
 
   defp validate_field(val, {type, {:transform, {mod, fun, args}}}, data)
        when is_atom(mod) and is_atom(fun) and is_list(args) do
     with :ok <- validate_field(val, type, data) do
-      {:ok, apply(mod, fun, [val | args])}
+      cond do
+        function_exported?(mod, fun, length(args) + 2) ->
+          {:ok, apply(mod, fun, [val, maybe_get_root_data(data) | args])}
+
+        function_exported?(mod, fun, length(args) + 1) ->
+          {:ok, apply(mod, fun, [val | args])}
+
+        true ->
+          template = "expected %{mod} to export %{fun} with arity from %{base} to %{arity}"
+          {:error, template, mod: mod, fun: fun, arity: length(args), base: length(args) + 1}
+      end
     end
   end
 

--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -665,6 +665,13 @@ defmodule Peri do
     end
   end
 
+  defp validate_field(val, {type, {:transform, mapper}}, data)
+       when is_function(mapper, 2) do
+    with :ok <- validate_field(val, type, data) do
+      {:ok, mapper.(val, maybe_get_root_data(data))}
+    end
+  end
+
   defp validate_field(val, {type, {:transform, {mod, fun}}}, data)
        when is_atom(mod) and is_atom(fun) do
     with :ok <- validate_field(val, type, data) do
@@ -945,6 +952,15 @@ defmodule Peri do
        do: :ok
 
   defp validate_type({type, {:transform, mapper}}, p) when is_function(mapper, 1),
+    do: validate_type(type, p)
+
+  defp validate_type({type, {:transform, mapper}}, p) when is_function(mapper, 2),
+    do: validate_type(type, p)
+
+  defp validate_type({type, {:transform, {_mod, _fun}}}, p),
+    do: validate_type(type, p)
+
+  defp validate_type({type, {:transform, {_mod, _fun, args}}}, p) when is_list(args),
     do: validate_type(type, p)
 
   defp validate_type({:required, {type, {:default, val}}}, _) do


### PR DESCRIPTION
**Description**
Allows the access of other data fields while applying the transformation (aka mapper) function
on a `:transform` field, example:

```elixir
import Peri

s = %{
  id: {:required, :string},
  name:
    {:string,
     {:transform,
      fn
        name, data -> (data[:id] && name <> "-#{data[:id]}") || name
      end}}
}

Peri.validate(s, %{id: 1, name: "maria"})
# {:ok, %{id, name: "maria-1"}}
```

It should also work on nested schemas (check test file) and handle errors.

**Related Issues**
closes #13

**Type of Change**
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
N/A
