### PR TITLE
Correctly handle nested results on transformations

### DIFF
--- a/test/peri_test.exs
+++ b/test/peri_test.exs
@@ -1539,6 +1539,61 @@ defmodule PeriTest do
     end
   end
 
+  describe "transform directive on nested schema type" do
+    test "it should apply the trasnformation on a nested schema type" do
+      nested = %{foo: :string}
+      parent = %{bar: {nested, {:transform, fn v -> v end}}}
+      data = %{bar: %{foo: "hello"}}
+      assert {:ok, ^data} = Peri.validate(parent, data)
+
+      # generic map type should pass too
+      parent = %{bar: {:map, {:transform, fn v -> v end}}}
+      data = %{bar: %{foo: "hello"}}
+      assert {:ok, ^data} = Peri.validate(parent, data)
+
+      # function are indeed being applied?
+      assert_raise RuntimeError, fn ->
+        parent = %{bar: {nested, {:transform, fn _ -> raise("boom") end}}}
+        data = %{bar: %{foo: "hello"}}
+        refute {:ok, ^data} = Peri.validate(parent, data)
+      end
+
+      assert_raise RuntimeError, fn ->
+        parent = %{bar: {:map, {:transform, fn _ -> raise("boom") end}}}
+        data = %{bar: %{foo: "hello"}}
+        refute {:ok, ^data} = Peri.validate(parent, data)
+      end
+    end
+
+    test "it should apply the mapper on nested schemas too by MFA" do
+      nested = %{foo: :string}
+      parent = %{bar: {nested, {:transform, {__MODULE__, :id}}}}
+      data = %{bar: %{foo: "10"}}
+      assert {:ok, ^data} = Peri.validate(parent, data)
+
+      # generic map type should pass too
+      parent = %{bar: {:map, {:transform, {__MODULE__, :id}}}}
+      data = %{bar: %{foo: "hello"}}
+      assert {:ok, ^data} = Peri.validate(parent, data)
+
+      # function are indeed being applied?
+      assert_raise RuntimeError, fn ->
+        parent = %{bar: {nested, {:transform, {__MODULE__, :boom}}}}
+        data = %{bar: %{foo: "hello"}}
+        refute {:ok, ^data} = Peri.validate(parent, data)
+      end
+
+      assert_raise RuntimeError, fn ->
+        parent = %{bar: {:map, {:transform, {__MODULE__, :boom}}}}
+        data = %{bar: %{foo: "hello"}}
+        refute {:ok, ^data} = Peri.validate(parent, data)
+      end
+    end
+  end
+
+  def id(v), do: v
+  def boom(_), do: raise("boom")
+
   defschema(:either_transform, %{
     value: {:either, {{:integer, {:transform, &double/1}}, {:string, {:transform, &upcase/1}}}}
   })


### PR DESCRIPTION
**Description**
`:transform` directive was not handling correctly the return when a nested schema was being passed as a type, that occurs because when there's a nested data value and type, the `validate_field/3` will return `{:ok, <nested>}` and not `:ok`.

given that, the `:transform` clause was matching only the `:ok` return and so on ignoring the nested data returned, so the mapper function wasn't being applied.

that didn't occur with `:map` type directive since the `validate_field/3` clause for this type will only return `:ok`, accepting any map structure you're passing as value.

**Related Issues**
closes #12

**Type of Change**
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
N/A
