### PR TITLE
fix: dependent validation behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ defmodule UserSchemas do
   }
 
   # if confirmation has the same value of password, the validation is ok
-  defp validate_confirmation(%{password: password}, password), do: :ok
+  defp validate_confirmation(password, password), do: :ok
 
   defp validate_confirmation(_confirmation, _password) do
     {:error, "confirmation should be equal to password", []}

--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -49,7 +49,7 @@ defmodule Peri do
     name: "John", age: 30, email: "john@example.com",
     address: %{street: "123 Main St", city: "Somewhere"},
     tags: ["science", "funky"], role: :admin,
-    geolocation: {12.2, 34.2}, 
+    geolocation: {12.2, 34.2},
     preferences: %{"theme" => "dark", "notifications" => "enabled"},
     scores: %{"math" => 95, "science" => 92},
     status: :active,
@@ -750,11 +750,12 @@ defmodule Peri do
     end
   end
 
-  defp validate_field(val, {:dependent, field, condition, type}, data) do
-    dependent_val = get_enumerable_value(data, field)
+  defp validate_field(val, {:dependent, field, condition, type}, parser) do
+    root = maybe_get_root_data(parser)
+    dependent_val = get_enumerable_value(root, field)
 
     with :ok <- condition.(val, dependent_val) do
-      validate_field(val, type, data)
+      validate_field(val, type, root)
     end
   end
 
@@ -1172,7 +1173,7 @@ defmodule Peri do
 
   defp validate_type({:dependent, cb}, _) when is_function(cb, 1), do: :ok
 
-  defp validate_type({:dependent, _, cb, type}, p) when is_function(cb, 1) do
+  defp validate_type({:dependent, _, cb, type}, p) when is_function(cb, 2) do
     validate_type(type, p)
   end
 


### PR DESCRIPTION
- fix `{:dependent, field, callback/2, type}` to work.
- fix README to reflect correct usage of dependent validation with callback/2.

**Description**
The current implementation of dependent validation with `{:dependent, field, callback/2, type}` does not work, as highlighted in https://github.com/zoedsoupe/peri/pull/23.

This PR fixes the implementation as well as the meta validation, and adds tests.

A slight adjustment to the README API usage has also been added - the callback's first parameter should be the value of field and not the entire map (otherwise specifying the field in the API is redundant).

Please double check if I have not broken any existing behavior 🙏 

**Related Issues**
[Link to any related issues or pull requests.](https://github.com/zoedsoupe/peri/pull/23.)

**Type of Change**
- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
Add any other context or screenshots about the pull request here.
