### PR TITLE
feat: split out `validation_result` from `validation` type for reuse

### DIFF
--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -138,7 +138,8 @@ defmodule Peri do
   ```
   """
 
-  @type validation :: (term -> :ok | {:error, template :: String.t(), context :: map | keyword})
+  @type validation :: (term -> validation_result)
+  @type validation_result :: :ok | {:error, template :: String.t(), context :: map | keyword}
   @type time_def :: :time | :date | :datetime | :naive_datetime | :duration
   @type string_def ::
           :string
@@ -172,7 +173,7 @@ defmodule Peri do
           | {schema_def, {:transform, {module, atom}}}
           | {schema_def, {:transform, {module, atom, list(term)}}}
   @type custom_def ::
-          {:custom, (term -> term)}
+          {:custom, validation}
           | {:custom, {module, atom}}
           | {:custom, {module, atom, list(term)}}
   @type cond_def ::


### PR DESCRIPTION
**Description**
Split out the return type from the `Peri.validation()` type definition, for easier reuse when writing custom validators. Prior to this, custom validators would need to redefine the result type for their type specs, which could eventually drift out of sync with the upstream type if it ever got updated for whatever reason.

Example usage for a custom validator:

```elixir
defmodule Example do
  import Peri

  defschema :example, %{
    foobar:  {:custom, &custom_validator/1}
  }

  @spec custom_validator(term()) :: Peri.validation_result()
  def custom_validator(value) do
    # do whatever
    :ok
  end
end
```

**Type of Change**
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
