### PR TITLE
feat: multiple validator options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ peri-*.tar
 /priv/plts/
 
 .claude
+.nix-mix
+.direnv

--- a/pages/types.md
+++ b/pages/types.md
@@ -42,6 +42,7 @@ Peri provides a comprehensive set of built-in types for schema validation.
 | `{:string, {:eq, value}}` | String equal to value | `{:string, {:eq, "exact"}}` |
 | `{:string, {:min, length}}` | String with minimum length | `{:string, {:min, 3}}` |
 | `{:string, {:max, length}}` | String with maximum length | `{:string, {:max, 50}}` |
+| `{:string, [...options]}` | String with multiple options | `{:string, [min: 8, max: 64, regex: ~r/^[a-zA-Z0-9-]+$/]}` |
 
 ## Integer Constraints
 
@@ -54,6 +55,20 @@ Peri provides a comprehensive set of built-in types for schema validation.
 | `{:integer, {:lt, value}}` | Integer less than value | `{:integer, {:lt, 100}}` |
 | `{:integer, {:lte, value}}` | Integer less than or equal | `{:integer, {:lte, 99}}` |
 | `{:integer, {:range, {min, max}}}` | Integer within range (inclusive) | `{:integer, {:range, {18, 65}}}` |
+| `{:integer, [...options]}` | Integer with multiple options | `{:integer, [gt: 12, lte: 96]}` |
+
+## Float Constraints
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `{:float, {:eq, value}}` | Float equal to value | `{:float, {:eq, 3.1415}}` |
+| `{:float, {:neq, value}}` | Float not equal to value | `{:float, {:neq, 1.9}}` |
+| `{:float, {:gt, value}}` | Float greater than value | `{:float, {:gt, 1.0}}` |
+| `{:float, {:gte, value}}` | Float greater than or equal | `{:float, {:gte, 9.12}}` |
+| `{:float, {:lt, value}}` | Float less than value | `{:float, {:lt, 10.0}}` |
+| `{:float, {:lte, value}}` | Float less than or equal | `{:float, {:lte, 99.999}}` |
+| `{:float, {:range, {min, max}}}` | Float within range (inclusive) | `{:float, {:range, {8.3, 15.3}}}` |
+| `{:float, [...options]}` | Float with multiple options | `{:float, [gt: 1.52, lte: 29.123]}` |
 
 ## Choice Types
 

--- a/test/peri_test.exs
+++ b/test/peri_test.exs
@@ -2595,4 +2595,44 @@ defmodule PeriTest do
       assert {:ok, ^data_y} = schema_oneof(data_y)
     end
   end
+
+  defschema(:schema_multiopts, %{
+    x: {:string, min: 3, max: 10, regex: ~r/^[a-z0-9-]+$/},
+    y: {:integer, gt: 6, lte: 14}
+  })
+
+  test "validates :string and :integer with multiple options" do
+    data = %{x: "foobar", y: 12}
+
+    assert {:ok, ^data} = schema_multiopts(data)
+  end
+
+  test "returns all errors when bad data is passed to a validator with multiple options" do
+    data = %{x: "a!", y: 16}
+
+    assert {:error,
+            [
+              %Peri.Error{
+                path: [:x],
+                key: :x,
+                content: %{regex: ~r/^[a-z0-9-]+$/},
+                message: "should match the ~r/^[a-z0-9-]+$/ pattern",
+                errors: nil
+              },
+              %Peri.Error{
+                path: [:x],
+                key: :x,
+                content: %{length: 3},
+                message: "should have the minimum length of 3",
+                errors: nil
+              },
+              %Peri.Error{
+                path: [:y],
+                key: :y,
+                content: %{value: 14},
+                message: "should be less then or equal to 14",
+                errors: nil
+              }
+            ]} = schema_multiopts(data)
+  end
 end


### PR DESCRIPTION
**Description**
Allow string and numeric validators to have multiple options provided, allowing for a regex validated string with separate min/max limits, or an integer in a range where one limit is exclusive.

Also updates the error reducer(?) to correctly handle multiple returned errors (instead of just one), and also now allows `{:error, template, context}` alongside already constructed `%Peri.Error{}`.

**Related Issues**
Link to any related issues or pull requests.

**Type of Change**
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
Add any other context or screenshots about the pull request here.
