### PR TITLE
feat: `:schema` validator that can accept additional keys

### DIFF
--- a/pages/types.md
+++ b/pages/types.md
@@ -33,6 +33,7 @@ Peri provides a comprehensive set of built-in types for schema validation.
 | `{:map, type}` | Map with values of specified type | `{:map, :integer}` |
 | `{:map, key_type, value_type}` | Map with typed keys and values | `{:map, :atom, :string}` |
 | `{:tuple, types}` | Tuple with elements of specified types | `{:tuple, [:float, :float]}` |
+| `{:schema, map_schema, {:additional_keys, type}}` | Map with some strictly defined fields, with extras under a different type | `{:schema, %{main: :string}, {:additional_keys, :integer}}` |
 
 ## String Constraints
 


### PR DESCRIPTION
**Description**
Add the `{:schema, schema, {:additional_keys, value_type}}` validator, as an equivalent to JSON schema's `additionalProperties` and Zod's `.catchall()`.

Also supports plain `{:schema, schema}` as an alternative to putting a nested schema directly, might be useful for some introspection tool, idk.

**Related Issues**
Closes #36.

**Type of Change**
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
Add any other context or screenshots about the pull request here.
