### PR TITLE
feat: add :meta wrapper and schema-level meta opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Peri is a schema validation library for Elixir, inspired by Clojure's Plumatic S
 - **Data Generation**: Generate sample data based on your schemas using StreamData
 - **Ecto Integration**: Convert Peri schemas to Ecto changesets for seamless database integration
 - **Validation Modes**: Choose between strict (default) and permissive validation modes
+- **Schema Metadata**: Attach docs, examples, and tooling hints via `{:meta, type, opts}` and schema-level meta opts
 
 ## Installation
 

--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -84,7 +84,25 @@ defmodule Peri do
   - `{:oneof, [type1, type2, ...]}` - One of the specified types
   - `{:cond, condition, true_type, false_type}` - Conditional validation based on callback
   - `{:dependent, callback}` - Dynamic type based on callback result
+  - `{:meta, type, opts}` - Attach documentation/example/description to a field; passthrough at validation
   - Nested maps for complex structures
+
+  ## Schema Metadata
+
+  Fields can carry metadata via the `{:meta, type, opts}` wrapper. Metadata is
+  ignored at validation time but available for documentation, JSON Schema export
+  (planned), and tooling. Blessed keys: `:doc`, `:title`, `:description`,
+  `:example`, `:deprecated`. User keys are preserved opaquely.
+
+  ```elixir
+  defschema :user, %{
+    email: {:meta, {:required, :string}, doc: "Login email", example: "a@b.io"},
+    age: {:meta, {:integer, gte: 0}, description: "Years"}
+  }, title: "User", description: "Account holder"
+  ```
+
+  Schema-level meta opts are exposed via the generated `__schema_meta__/1`
+  function. Validation opts (e.g. `:mode`) are split out, not surfaced as meta.
 
   ## Callback Functions for :cond and :dependent
 
@@ -196,6 +214,7 @@ defmodule Peri do
           | {:either, {schema_def, schema_def}}
           | {:oneof, list(schema_def)}
           | {:required, schema_def}
+          | {:meta, schema_def, keyword}
           | {:enum, list(term)}
           | {:list, schema_def}
           | {:map, schema_def}
@@ -234,7 +253,16 @@ defmodule Peri do
           name: :string,
           email: {:required, :string}
         }, mode: :permissive
+
+        # With metadata (field-level and schema-level)
+        defschema :documented_user, %{
+          email: {:meta, {:required, :string}, doc: "Login email", example: "a@b.io"}
+        }, title: "User", description: "Account holder"
       end
+
+      # Schema-level metadata is accessible via __schema_meta__/1:
+      MySchemas.__schema_meta__(:documented_user)
+      # => [title: "User", description: "Account holder"]
 
       user_data = %{name: "John", age: 30, email: "john@example.com"}
       MySchemas.user(user_data)

--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -1369,8 +1369,13 @@ defmodule Peri do
     {:error, template, [value: val, type: type]}
   end
 
-  defp validate_type({:meta, type, meta_opts}, p) when is_list(meta_opts),
-    do: validate_type(type, p)
+  defp validate_type({:meta, type, meta_opts}, p) when is_list(meta_opts) do
+    if Keyword.keyword?(meta_opts),
+      do: validate_type(type, p),
+      else:
+        {:error, "expected meta opts to be a keyword list, got %{actual}",
+         actual: inspect(meta_opts)}
+  end
 
   defp validate_type({:meta, _type, meta_opts}, _p) do
     {:error, "expected meta opts to be a keyword list, got %{actual}", actual: inspect(meta_opts)}

--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -249,12 +249,19 @@ defmodule Peri do
       MySchemas.flexible_user(flexible_data)
       # => {:ok, %{name: "John", email: "john@example.com", role: "admin"}}
   """
+  @validation_opts [:mode]
+
   defmacro defschema(name, schema, opts \\ []) do
     bang = :"#{name}!"
+    {validation_opts, meta_opts} = Keyword.split(opts, @validation_opts)
 
     quote do
       def get_schema(unquote(name)) do
         unquote(schema)
+      end
+
+      def __schema_meta__(unquote(name)) do
+        unquote(meta_opts)
       end
 
       if Code.ensure_loaded?(Ecto) do
@@ -265,13 +272,13 @@ defmodule Peri do
 
       def unquote(name)(data) do
         with {:ok, schema} <- Peri.validate_schema(unquote(schema)) do
-          Peri.validate(schema, data, unquote(opts))
+          Peri.validate(schema, data, unquote(validation_opts))
         end
       end
 
       def unquote(bang)(data) do
         with {:ok, valid_schema} <- Peri.validate_schema(unquote(schema)),
-             {:ok, valid_data} <- Peri.validate(valid_schema, data, unquote(opts)) do
+             {:ok, valid_data} <- Peri.validate(valid_schema, data, unquote(validation_opts)) do
           valid_data
         else
           {:error, errors} -> raise Peri.InvalidSchema, errors
@@ -480,6 +487,10 @@ defmodule Peri do
     end
   end
 
+  defp do_filter_data(data, {key, {:meta, type, _meta_opts}}, acc, opts) do
+    do_filter_data(data, {key, type}, acc, opts)
+  end
+
   defp do_filter_data(data, {key, type}, acc, opts) do
     string_key = to_string(key)
     value = get_enumerable_value(data, key)
@@ -641,6 +652,9 @@ defmodule Peri do
     {:error, "expected literal value %{expected} but got %{actual}",
      [expected: inspect(literal), actual: inspect(val)]}
   end
+
+  defp validate_field(val, {:meta, type, _meta_opts}, data, opts),
+    do: validate_field(val, type, data, opts)
 
   defp validate_field(nil, {:required, type}, _data, _opts) do
     {:error, "is required, expected type of %{expected}", expected: type}
@@ -1325,6 +1339,13 @@ defmodule Peri do
   defp validate_type({:required, {type, {:default, val}}}, _) do
     template = "cannot set default value of %{value} for required field of type %{type}"
     {:error, template, [value: val, type: type]}
+  end
+
+  defp validate_type({:meta, type, meta_opts}, p) when is_list(meta_opts),
+    do: validate_type(type, p)
+
+  defp validate_type({:meta, _type, meta_opts}, _p) do
+    {:error, "expected meta opts to be a keyword list, got %{actual}", actual: inspect(meta_opts)}
   end
 
   defp validate_type({:required, type}, p), do: validate_type(type, p)

--- a/lib/peri/ecto.ex
+++ b/lib/peri/ecto.ex
@@ -66,6 +66,10 @@ if Code.ensure_loaded?(Ecto) do
       parse_peri({key, type}, ecto)
     end
 
+    def parse_peri({key, {:meta, type, _opts}}, ecto) do
+      parse_peri({key, type}, ecto)
+    end
+
     def parse_peri({key, {type, {:default, {mod, fun}}}}, ecto) do
       put_in(ecto[key][:default], apply(mod, fun, []))
       |> then(&parse_peri({key, type}, &1))

--- a/lib/peri/generatable.ex
+++ b/lib/peri/generatable.ex
@@ -82,6 +82,8 @@ if Code.ensure_loaded?(StreamData) do
 
     def gen({:required, type}), do: gen(type)
 
+    def gen({:meta, type, _opts}), do: gen(type)
+
     def gen({:enum, choices}) do
       choices
       |> Enum.map(&StreamData.constant/1)

--- a/pages/types.md
+++ b/pages/types.md
@@ -90,6 +90,30 @@ Peri provides a comprehensive set of built-in types for schema validation.
 | `{type, {:default, {m, f}}}` | Default from MFA | `{:string, {:default, {MyMod, :get_default}}}` |
 | `{type, {:transform, fun}}` | Transform value | `{:string, {:transform, &String.upcase/1}}` |
 | `{type, {:transform, {m, f}}}` | Transform with MFA | `{:string, {:transform, {MyMod, :clean}}}` |
+| `{:meta, type, opts}` | Attach metadata, passthrough validation | `{:meta, {:required, :string}, doc: "Login email", example: "a@b.io"}` |
+
+## Schema Metadata
+
+The `{:meta, type, opts}` wrapper attaches documentation/tooling info to a field
+without affecting validation. Blessed keys: `:doc`, `:title`, `:description`,
+`:example`, `:deprecated`. User keys are preserved opaquely.
+
+`defschema` accepts schema-level meta opts (any non-validation key), exposed via
+the generated `__schema_meta__/1`:
+
+```elixir
+defmodule MySchemas do
+  import Peri
+
+  defschema :user, %{
+    email: {:meta, {:required, :string}, doc: "Login email", example: "a@b.io"},
+    age: {:meta, {:integer, gte: 0}, description: "Years"}
+  }, title: "User", description: "Account holder"
+end
+
+MySchemas.__schema_meta__(:user)
+# => [title: "User", description: "Account holder"]
+```
 
 ## Custom Validation
 

--- a/test/meta_test.exs
+++ b/test/meta_test.exs
@@ -1,0 +1,96 @@
+defmodule Peri.MetaTest do
+  use ExUnit.Case, async: true
+
+  import Peri
+
+  defschema(
+    :user,
+    %{
+      email: {:meta, {:required, :string}, doc: "Login email", example: "a@b.io"},
+      age: {:meta, {:integer, gte: 0}, description: "Years"}
+    },
+    title: "User",
+    description: "Account holder",
+    custom_key: "anything"
+  )
+
+  defschema(:nested, %{
+    profile: {:meta, %{name: {:required, :string}, bio: :string}, doc: "User profile"}
+  })
+
+  defschema(:plain, %{name: :string})
+
+  describe "{:meta, type, opts} wrapper" do
+    test "passthrough validation succeeds for valid data" do
+      assert {:ok, %{email: "a@b.io", age: 30}} =
+               user(%{email: "a@b.io", age: 30})
+    end
+
+    test "wrapped :required still enforced" do
+      assert {:error, [%Peri.Error{path: [:email]}]} = user(%{age: 30})
+    end
+
+    test "wrapped constraints still enforced" do
+      assert {:error, [%Peri.Error{path: [:age]}]} =
+               user(%{email: "a@b.io", age: -1})
+    end
+
+    test "wrapped type mismatch errors normally" do
+      assert {:error, [%Peri.Error{path: [:age]}]} =
+               user(%{email: "a@b.io", age: "thirty"})
+    end
+
+    test "nested schema inside meta validates and filters" do
+      assert {:ok, %{profile: %{name: "Jane", bio: "hi"}}} =
+               nested(%{profile: %{name: "Jane", bio: "hi", drop: "x"}})
+    end
+
+    test "nested schema inside meta enforces required" do
+      assert {:error,
+              [
+                %Peri.Error{
+                  path: [:profile],
+                  errors: [%Peri.Error{path: [:profile, :name]}]
+                }
+              ]} = nested(%{profile: %{bio: "hi"}})
+    end
+
+    test "validate_schema accepts meta wrapper" do
+      schema = %{x: {:meta, :integer, doc: "n"}}
+      assert {:ok, ^schema} = Peri.validate_schema(schema)
+    end
+
+    test "validate_schema rejects non-keyword meta opts" do
+      schema = %{x: {:meta, :integer, "not a keyword"}}
+      assert {:error, _} = Peri.validate_schema(schema)
+    end
+  end
+
+  describe "defschema schema-level meta opts" do
+    test "blessed keys preserved on __schema_meta__" do
+      meta = __MODULE__.__schema_meta__(:user)
+      assert Keyword.get(meta, :title) == "User"
+      assert Keyword.get(meta, :description) == "Account holder"
+    end
+
+    test "user keys preserved opaquely" do
+      meta = __MODULE__.__schema_meta__(:user)
+      assert Keyword.get(meta, :custom_key) == "anything"
+    end
+
+    test "validation opts excluded from meta" do
+      defmodule WithMode do
+        import Peri
+        defschema(:s, %{n: :integer}, mode: :permissive, title: "S")
+      end
+
+      assert WithMode.__schema_meta__(:s) == [title: "S"]
+      assert {:ok, %{n: 1, extra: "k"}} = WithMode.s(%{n: 1, extra: "k"})
+    end
+
+    test "schema with no meta returns empty list" do
+      assert plain(%{name: "x"}) == {:ok, %{name: "x"}}
+      assert __MODULE__.__schema_meta__(:plain) == []
+    end
+  end
+end

--- a/test/meta_test.exs
+++ b/test/meta_test.exs
@@ -93,4 +93,37 @@ defmodule Peri.MetaTest do
       assert __MODULE__.__schema_meta__(:plain) == []
     end
   end
+
+  if Code.ensure_loaded?(StreamData) do
+    describe "Peri.Generatable with meta" do
+      test "unwraps meta and generates inner type" do
+        schema = %{n: {:meta, :integer, doc: "n"}}
+        {:ok, stream} = Peri.generate(schema)
+        [sample] = Enum.take(stream, 1)
+        assert is_integer(sample.n)
+      end
+    end
+  end
+
+  if Code.ensure_loaded?(Ecto) do
+    describe "Peri.Ecto with meta" do
+      test "to_changeset! unwraps meta wrapper" do
+        schema = %{
+          email: {:meta, {:required, :string}, doc: "Login"},
+          age: {:meta, :integer, description: "Years"}
+        }
+
+        cs = Peri.to_changeset!(schema, %{email: "a@b.io", age: 30})
+        assert cs.valid?
+        assert cs.changes == %{email: "a@b.io", age: 30}
+      end
+
+      test "meta-wrapped required is enforced via Ecto" do
+        schema = %{email: {:meta, {:required, :string}, doc: "Login"}}
+        cs = Peri.to_changeset!(schema, %{})
+        refute cs.valid?
+        assert {"can't be blank", _} = cs.errors[:email]
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Description**
Adds `{:meta, type, opts}` passthrough wrapper so fields can carry doc/title/description/example/deprecated (plus opaque user keys) without affecting validation. `defschema` accepts schema-level meta opts; meta is split from validation opts (`:mode`) and exposed via generated `__schema_meta__/1`. Foundation for upcoming JSON Schema export and custom-error i18n phases.

**Related Issues**
Phase 1 of the malli-inspired feature plan.

**Type of Change**
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
Pure passthrough — zero runtime cost, fully additive, no breaking changes. `validate_type` rejects non-keyword meta opts. `do_filter_data` unwraps meta so nested schemas inside the wrapper still filter strict-mode keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schemas now support metadata options (title, description, custom fields) that are preserved and retrievable separately from validation settings.
  * Fields can be wrapped with metadata information while maintaining type validation and constraints.
  * Schema metadata is accessible and excludes validation-specific configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->