### PR TITLE
feat: add JSON Schema (Draft 7) bidirectional conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Peri is a schema validation library for Elixir, inspired by Clojure's Plumatic S
 - **Ecto Integration**: Convert Peri schemas to Ecto changesets for seamless database integration
 - **Validation Modes**: Choose between strict (default) and permissive validation modes
 - **Schema Metadata**: Attach docs, examples, and tooling hints via `{:meta, type, opts}` and schema-level meta opts
+- **JSON Schema**: Bidirectional conversion (Draft 7) via `Peri.to_json_schema/2` and `Peri.from_json_schema/1`
 
 ## Installation
 
@@ -56,6 +57,7 @@ For detailed documentation on types, validation patterns, and integrations, see:
 - **[Validation Patterns](pages/validation.md)** - Conditional, dependent, and custom validation  
 - **[Ecto Integration](pages/ecto.md)** - Converting schemas to Ecto changesets
 - **[Data Generation](pages/generation.md)** - Generate sample data with StreamData
+- **[JSON Schema](pages/json_schema.md)** - Convert to and from JSON Schema (Draft 7)
 
 ## Why the Name "Peri"?
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Peri is a schema validation library for Elixir, inspired by Clojure's Plumatic S
 ## Installation
 
 Add this line to your `mix.exs`:
+
 ```elixir
 defp deps do
   [
@@ -54,7 +55,7 @@ Peri.validate(MyApp.Schemas.get_schema(:user), data_with_extra, mode: :permissiv
 For detailed documentation on types, validation patterns, and integrations, see:
 
 - **[Types Reference](pages/types.md)** - All available types and constraints
-- **[Validation Patterns](pages/validation.md)** - Conditional, dependent, and custom validation  
+- **[Validation Patterns](pages/validation.md)** - Conditional, dependent, and custom validation
 - **[Ecto Integration](pages/ecto.md)** - Converting schemas to Ecto changesets
 - **[Data Generation](pages/generation.md)** - Generate sample data with StreamData
 - **[JSON Schema](pages/json_schema.md)** - Convert to and from JSON Schema (Draft 7)

--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -377,6 +377,30 @@ defmodule Peri do
     end
   end
 
+  @doc """
+  Converts a Peri schema into a JSON Schema (Draft 7) map.
+
+  Reads `{:meta, type, opts}` annotations and emits `title`, `description`,
+  `examples`, `deprecated`. Dynamic types degrade per `:on_unsupported`
+  (`:omit | :true_schema | :raise`, default `:omit`).
+
+  ## Examples
+
+      iex> Peri.to_json_schema(%{name: {:required, :string}})
+      %{"type" => "object", "properties" => %{"name" => %{"type" => "string"}}, "required" => ["name"]}
+  """
+  @spec to_json_schema(schema, Peri.JSONSchema.Encoder.opts()) :: map
+  defdelegate to_json_schema(schema, opts \\ []), to: Peri.JSONSchema.Encoder, as: :encode
+
+  @doc """
+  Decodes a JSON Schema (Draft 7) map into a Peri schema.
+
+  Returns `{:ok, schema}` if the resulting Peri schema is valid, otherwise
+  `{:error, errors}`.
+  """
+  @spec from_json_schema(map) :: {:ok, schema} | {:error, term}
+  defdelegate from_json_schema(json_schema), to: Peri.JSONSchema.Decoder, as: :decode
+
   if Code.ensure_loaded?(StreamData) do
     @doc """
     Generates sample data based on the given schema definition using `StreamData`.

--- a/lib/peri/json_schema/decoder.ex
+++ b/lib/peri/json_schema/decoder.ex
@@ -45,6 +45,10 @@ defmodule Peri.JSONSchema.Decoder do
     end
   end
 
+  # Peri's `:oneof` succeeds on the first matching branch, which mirrors
+  # JSON Schema's `anyOf` semantics. JSON Schema's `oneOf` requires *exactly
+  # one* match; Peri cannot express that constraint, so `oneOf` is decoded
+  # to `:oneof` lossily (treated as `anyOf`).
   defp convert_schema(%{"anyOf" => schemas}) when is_list(schemas) do
     convert_schema(%{"oneOf" => schemas})
   end
@@ -70,7 +74,7 @@ defmodule Peri.JSONSchema.Decoder do
     Map.new(properties, fn {key, prop_schema} ->
       peri_type = convert_schema(prop_schema)
       final = if key in required, do: {:required, peri_type}, else: peri_type
-      {String.to_atom(key), final}
+      {safe_key(key), final}
     end)
   end
 
@@ -79,6 +83,14 @@ defmodule Peri.JSONSchema.Decoder do
   end
 
   defp convert_object(_), do: %{}
+
+  defp safe_key(key) when is_atom(key), do: key
+
+  defp safe_key(key) when is_binary(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> key
+  end
 
   defp convert_array(%{"items" => items}) do
     {:list, convert_schema(items)}
@@ -91,7 +103,10 @@ defmodule Peri.JSONSchema.Decoder do
     |> apply_constraint(schema, "minLength", :min)
     |> apply_constraint(schema, "maxLength", :max)
     |> apply_constraint(schema, "pattern", fn pattern ->
-      {:regex, Regex.compile!(pattern)}
+      case Regex.compile(pattern) do
+        {:ok, regex} -> {:regex, regex}
+        {:error, _reason} -> nil
+      end
     end)
     |> apply_constraint(schema, "format", fn format ->
       case format do
@@ -121,11 +136,13 @@ defmodule Peri.JSONSchema.Decoder do
     |> apply_constraint(schema, "exclusiveMaximum", :lt)
   end
 
-  defp apply_constraint({base, constraint}, schema, json_key, handler)
-       when is_tuple(constraint) do
+  defp apply_constraint({base, constraints}, schema, json_key, handler)
+       when is_tuple(constraints) or is_list(constraints) do
+    existing = List.wrap(constraints)
+
     case apply_constraint(base, schema, json_key, handler) do
-      {_base, new_constraint} -> {base, [constraint, new_constraint]}
-      _base -> {base, constraint}
+      {_base, new_constraint} -> {base, existing ++ [new_constraint]}
+      _base -> {base, constraints}
     end
   end
 

--- a/lib/peri/json_schema/decoder.ex
+++ b/lib/peri/json_schema/decoder.ex
@@ -1,0 +1,155 @@
+defmodule Peri.JSONSchema.Decoder do
+  @moduledoc """
+  Decodes a JSON Schema (Draft 7) map into a Peri schema definition.
+
+  Returns `{:ok, schema}` on success or `{:error, errors}` if the resulting
+  Peri schema fails `Peri.validate_schema/1`.
+
+  Prefer `Peri.from_json_schema/1` as the public entry point.
+  """
+
+  @spec decode(map) :: {:ok, Peri.schema()} | {:error, term}
+  def decode(json_schema) when is_map(json_schema) do
+    schema = convert_schema(json_schema)
+    Peri.validate_schema(schema)
+  end
+
+  defp convert_schema(%{"type" => "object"} = schema), do: convert_object(schema)
+  defp convert_schema(%{"type" => "array"} = schema), do: convert_array(schema)
+  defp convert_schema(%{"type" => "string"} = schema), do: convert_string(schema)
+  defp convert_schema(%{"type" => "number"} = schema), do: convert_number(schema)
+  defp convert_schema(%{"type" => "integer"} = schema), do: convert_integer(schema)
+  defp convert_schema(%{"type" => "boolean"}), do: :boolean
+  defp convert_schema(%{"type" => "null"}), do: {:literal, nil}
+
+  defp convert_schema(%{"type" => types} = schema) when is_list(types) do
+    schemas = Enum.map(types, fn type -> convert_schema(Map.put(schema, "type", type)) end)
+
+    case schemas do
+      [single] -> single
+      [a, b] -> {:either, {a, b}}
+      multiple -> {:oneof, multiple}
+    end
+  end
+
+  defp convert_schema(%{"const" => value}), do: {:literal, value}
+  defp convert_schema(%{"enum" => values}) when is_list(values), do: {:enum, values}
+
+  defp convert_schema(%{"oneOf" => schemas}) when is_list(schemas) do
+    converted = Enum.map(schemas, &convert_schema/1)
+
+    case converted do
+      [single] -> single
+      [a, b] -> {:either, {a, b}}
+      multiple -> {:oneof, multiple}
+    end
+  end
+
+  defp convert_schema(%{"anyOf" => schemas}) when is_list(schemas) do
+    convert_schema(%{"oneOf" => schemas})
+  end
+
+  defp convert_schema(%{"allOf" => schemas}) when is_list(schemas) do
+    Enum.reduce(schemas, %{}, fn schema, acc ->
+      case convert_schema(schema) do
+        map when is_map(map) -> Map.merge(acc, map)
+        _other -> acc
+      end
+    end)
+  end
+
+  defp convert_schema(%{"additionalProperties" => add_props}) when is_map(add_props) do
+    {:map, convert_schema(add_props)}
+  end
+
+  defp convert_schema(_), do: :any
+
+  defp convert_object(%{"properties" => properties} = schema) do
+    required = Map.get(schema, "required", [])
+
+    Map.new(properties, fn {key, prop_schema} ->
+      peri_type = convert_schema(prop_schema)
+      final = if key in required, do: {:required, peri_type}, else: peri_type
+      {String.to_atom(key), final}
+    end)
+  end
+
+  defp convert_object(%{"additionalProperties" => add_props}) when is_map(add_props) do
+    {:map, convert_schema(add_props)}
+  end
+
+  defp convert_object(_), do: %{}
+
+  defp convert_array(%{"items" => items}) do
+    {:list, convert_schema(items)}
+  end
+
+  defp convert_array(_), do: {:list, :any}
+
+  defp convert_string(schema) do
+    :string
+    |> apply_constraint(schema, "minLength", :min)
+    |> apply_constraint(schema, "maxLength", :max)
+    |> apply_constraint(schema, "pattern", fn pattern ->
+      {:regex, Regex.compile!(pattern)}
+    end)
+    |> apply_constraint(schema, "format", fn format ->
+      case format do
+        "email" -> {:regex, ~r/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/}
+        "uri" -> {:regex, ~r/^[a-zA-Z][a-zA-Z\d+.-]*:/}
+        "date" -> :date
+        "time" -> :time
+        "date-time" -> :datetime
+        _ -> nil
+      end
+    end)
+  end
+
+  defp convert_number(schema) do
+    :float
+    |> apply_constraint(schema, "minimum", :gte)
+    |> apply_constraint(schema, "maximum", :lte)
+    |> apply_constraint(schema, "exclusiveMinimum", :gt)
+    |> apply_constraint(schema, "exclusiveMaximum", :lt)
+  end
+
+  defp convert_integer(schema) do
+    :integer
+    |> apply_constraint(schema, "minimum", :gte)
+    |> apply_constraint(schema, "maximum", :lte)
+    |> apply_constraint(schema, "exclusiveMinimum", :gt)
+    |> apply_constraint(schema, "exclusiveMaximum", :lt)
+  end
+
+  defp apply_constraint({base, constraint}, schema, json_key, handler)
+       when is_tuple(constraint) do
+    case apply_constraint(base, schema, json_key, handler) do
+      {_base, new_constraint} -> {base, [constraint, new_constraint]}
+      _base -> {base, constraint}
+    end
+  end
+
+  defp apply_constraint(base, schema, json_key, peri_constraint) when is_atom(peri_constraint) do
+    case Map.get(schema, json_key) do
+      nil -> base
+      value -> {base, {peri_constraint, value}}
+    end
+  end
+
+  defp apply_constraint(base, schema, json_key, converter) when is_function(converter) do
+    case Map.get(schema, json_key) do
+      nil ->
+        base
+
+      value ->
+        case converter.(value) do
+          nil -> base
+          {:regex, regex} when base == :string -> {:string, {:regex, regex}}
+          :date -> :date
+          :time -> :time
+          :datetime -> :datetime
+          constraint -> {base, constraint}
+        end
+    end
+  end
+end

--- a/lib/peri/json_schema/encoder.ex
+++ b/lib/peri/json_schema/encoder.ex
@@ -1,0 +1,211 @@
+defmodule Peri.JSONSchema.Encoder do
+  @moduledoc """
+  Encodes a Peri schema definition into a JSON Schema (Draft 7) map.
+
+  Field-level metadata attached via `{:meta, type, opts}` is read during
+  encoding and surfaced as JSON Schema annotation keywords (`title`,
+  `description`, `examples`, `deprecated`).
+
+  Dynamic Peri types (`:dependent`, `:cond`, `:custom`) cannot be expressed
+  statically. The `:on_unsupported` option controls the fallback:
+
+    - `:omit` (default) — emit `%{}` (true schema)
+    - `:true_schema` — same as `:omit`
+    - `:raise` — raise `Peri.JSONSchema.Encoder.UnsupportedTypeError`
+
+  Prefer `Peri.to_json_schema/2` as the public entry point.
+  """
+
+  @type opts :: [on_unsupported: :omit | :true_schema | :raise]
+
+  defmodule UnsupportedTypeError do
+    @moduledoc false
+    defexception [:type, :reason]
+
+    @impl true
+    def message(%{type: type, reason: reason}) do
+      "cannot encode #{inspect(type)} to JSON Schema: #{reason}"
+    end
+  end
+
+  @meta_keys [:title, :description, :example, :deprecated]
+
+  @spec encode(Peri.schema(), opts) :: map
+  def encode(schema, opts \\ [])
+
+  def encode(schema, opts) when is_map(schema) do
+    encode_object(schema, opts)
+  end
+
+  def encode(schema, opts), do: convert(schema, opts)
+
+  defp encode_object(schema, opts) do
+    properties =
+      Map.new(schema, fn {key, type} ->
+        {to_string(key), convert(type, opts)}
+      end)
+
+    required =
+      schema
+      |> Enum.filter(fn {_k, t} -> required?(t) end)
+      |> Enum.map(fn {k, _t} -> to_string(k) end)
+
+    base = %{"type" => "object", "properties" => properties}
+    if Enum.empty?(required), do: base, else: Map.put(base, "required", required)
+  end
+
+  defp convert({:meta, type, meta_opts}, opts) when is_list(meta_opts) do
+    type
+    |> convert(opts)
+    |> apply_meta(meta_opts)
+  end
+
+  defp convert({:required, type}, opts), do: convert(type, opts)
+
+  defp convert({type, {:default, default}}, opts),
+    do: Map.put(convert(type, opts), "default", default)
+
+  defp convert(:string, _), do: %{"type" => "string"}
+  defp convert(:integer, _), do: %{"type" => "integer"}
+  defp convert(:float, _), do: %{"type" => "number"}
+  defp convert(:boolean, _), do: %{"type" => "boolean"}
+  defp convert(:atom, _), do: %{"type" => "string"}
+  defp convert(:any, _), do: %{}
+  defp convert(:map, _), do: %{"type" => "object"}
+  defp convert(nil, _), do: %{"type" => "null"}
+
+  defp convert(:date, _), do: %{"type" => "string", "format" => "date"}
+  defp convert(:time, _), do: %{"type" => "string", "format" => "time"}
+  defp convert(:datetime, _), do: %{"type" => "string", "format" => "date-time"}
+  defp convert(:naive_datetime, _), do: %{"type" => "string", "format" => "date-time"}
+  defp convert(:duration, _), do: %{"type" => "string", "format" => "duration"}
+
+  defp convert({:literal, value}, _), do: %{"const" => value}
+  defp convert({:enum, values}, _) when is_list(values), do: %{"enum" => values}
+
+  defp convert({:string, {:regex, %Regex{source: pattern}}}, _),
+    do: %{"type" => "string", "pattern" => pattern}
+
+  defp convert({:string, {:eq, value}}, _), do: %{"type" => "string", "const" => value}
+  defp convert({:string, {:min, min}}, _), do: %{"type" => "string", "minLength" => min}
+  defp convert({:string, {:max, max}}, _), do: %{"type" => "string", "maxLength" => max}
+
+  defp convert({:string, opts}, encoder_opts) when is_list(opts) do
+    Enum.reduce(opts, %{"type" => "string"}, fn opt, acc ->
+      Map.merge(acc, convert({:string, opt}, encoder_opts))
+    end)
+  end
+
+  defp convert({type, {:eq, value}}, _) when type in [:integer, :float] do
+    Map.put(numeric_base(type), "const", value)
+  end
+
+  defp convert({type, {:neq, value}}, _) when type in [:integer, :float] do
+    Map.put(numeric_base(type), "not", %{"const" => value})
+  end
+
+  defp convert({type, {:gt, value}}, _) when type in [:integer, :float],
+    do: Map.put(numeric_base(type), "exclusiveMinimum", value)
+
+  defp convert({type, {:gte, value}}, _) when type in [:integer, :float],
+    do: Map.put(numeric_base(type), "minimum", value)
+
+  defp convert({type, {:lt, value}}, _) when type in [:integer, :float],
+    do: Map.put(numeric_base(type), "exclusiveMaximum", value)
+
+  defp convert({type, {:lte, value}}, _) when type in [:integer, :float],
+    do: Map.put(numeric_base(type), "maximum", value)
+
+  defp convert({type, {:range, {min, max}}}, _) when type in [:integer, :float] do
+    numeric_base(type)
+    |> Map.put("minimum", min)
+    |> Map.put("maximum", max)
+  end
+
+  defp convert({type, opts}, encoder_opts) when type in [:integer, :float] and is_list(opts) do
+    Enum.reduce(opts, numeric_base(type), fn opt, acc ->
+      Map.merge(acc, convert({type, opt}, encoder_opts))
+    end)
+  end
+
+  defp convert({:list, item_type}, opts) do
+    %{"type" => "array", "items" => convert(item_type, opts)}
+  end
+
+  defp convert({:map, value_type}, opts) do
+    %{"type" => "object", "additionalProperties" => convert(value_type, opts)}
+  end
+
+  defp convert({:map, _key_type, value_type}, opts) do
+    %{"type" => "object", "additionalProperties" => convert(value_type, opts)}
+  end
+
+  defp convert({:tuple, types}, opts) do
+    %{
+      "type" => "array",
+      "items" => Enum.map(types, &convert(&1, opts)),
+      "minItems" => length(types),
+      "maxItems" => length(types)
+    }
+  end
+
+  defp convert({:either, {a, b}}, opts) do
+    %{"oneOf" => [convert(a, opts), convert(b, opts)]}
+  end
+
+  defp convert({:oneof, types}, opts) when is_list(types) do
+    %{"oneOf" => Enum.map(types, &convert(&1, opts))}
+  end
+
+  defp convert({:schema, type}, opts), do: convert(type, opts)
+
+  defp convert({:schema, type, {:additional_keys, value_type}}, opts) when is_map(type) do
+    type
+    |> encode_object(opts)
+    |> Map.put("additionalProperties", convert(value_type, opts))
+  end
+
+  defp convert({type, {:transform, _}}, opts), do: convert(type, opts)
+
+  defp convert({:custom, _} = node, opts), do: unsupported(node, "custom validator", opts)
+  defp convert({:cond, _, _, _} = node, opts), do: unsupported(node, "conditional schema", opts)
+  defp convert({:dependent, _} = node, opts), do: unsupported(node, "dependent schema", opts)
+  defp convert({:dependent, _, _} = node, opts), do: unsupported(node, "dependent schema", opts)
+
+  defp convert({:dependent, _, _, _} = node, opts),
+    do: unsupported(node, "dependent schema", opts)
+
+  defp convert({:dependent, _, _, _, _} = node, opts),
+    do: unsupported(node, "dependent schema", opts)
+
+  defp convert(schema, opts) when is_map(schema), do: encode_object(schema, opts)
+
+  defp convert(other, opts), do: unsupported(other, "unknown type", opts)
+
+  defp unsupported(type, reason, opts) do
+    case Keyword.get(opts, :on_unsupported, :omit) do
+      :raise -> raise UnsupportedTypeError, type: type, reason: reason
+      _ -> %{}
+    end
+  end
+
+  defp numeric_base(:integer), do: %{"type" => "integer"}
+  defp numeric_base(:float), do: %{"type" => "number"}
+
+  defp apply_meta(schema, meta_opts) do
+    Enum.reduce(meta_opts, schema, fn
+      {key, value}, acc when key in @meta_keys ->
+        put_meta(acc, key, value)
+
+      _, acc ->
+        acc
+    end)
+  end
+
+  defp put_meta(schema, :example, value), do: Map.put(schema, "examples", List.wrap(value))
+  defp put_meta(schema, key, value), do: Map.put(schema, Atom.to_string(key), value)
+
+  defp required?({:required, _}), do: true
+  defp required?({:meta, type, _}), do: required?(type)
+  defp required?(_), do: false
+end

--- a/pages/json_schema.md
+++ b/pages/json_schema.md
@@ -1,0 +1,90 @@
+# JSON Schema
+
+Peri can convert schemas to and from JSON Schema (Draft 7) maps.
+
+## Encoding
+
+```elixir
+schema = %{
+  name: {:required, :string},
+  age: {:integer, gte: 0},
+  email: {:meta, {:required, :string}, description: "Login email", example: "a@b.io"}
+}
+
+Peri.to_json_schema(schema)
+# => %{
+#   "type" => "object",
+#   "properties" => %{
+#     "name" => %{"type" => "string"},
+#     "age" => %{"type" => "integer", "minimum" => 0},
+#     "email" => %{
+#       "type" => "string",
+#       "description" => "Login email",
+#       "examples" => ["a@b.io"]
+#     }
+#   },
+#   "required" => ["name", "email"]
+# }
+```
+
+### Metadata
+
+`{:meta, type, opts}` annotations are read during encoding. Blessed keys map to
+JSON Schema annotation keywords:
+
+| Peri meta key | JSON Schema key |
+|---------------|-----------------|
+| `:title`      | `title`         |
+| `:description`| `description`   |
+| `:example`    | `examples` (wrapped in array) |
+| `:deprecated` | `deprecated`    |
+
+Non-blessed user keys are preserved as Peri-side metadata only and are not
+written to the JSON Schema.
+
+### Type mapping
+
+| Peri | JSON Schema |
+|------|-------------|
+| `:string`, `:integer`, `:float`, `:boolean` | `"type"` keyword |
+| `:date`, `:time`, `:datetime` | `"string"` + `"format"` |
+| `{:list, t}` | `"array"` + `"items"` |
+| `{:map, t}`, `{:map, k, v}` | `"object"` + `"additionalProperties"` |
+| `{:tuple, ts}` | fixed-length `"array"` |
+| `{:enum, vs}` | `"enum"` |
+| `{:literal, v}` | `"const"` |
+| `{:either, {a, b}}`, `{:oneof, ts}` | `"oneOf"` |
+| `{:required, t}` | adds key to parent `"required"` |
+| `{type, gte: n}` | `"minimum"` |
+| `{type, gt: n}` | `"exclusiveMinimum"` |
+| `{:string, {:regex, r}}` | `"pattern"` |
+
+### Dynamic types
+
+`:dependent`, `:cond`, `:custom`, and `{type, {:transform, _}}` cannot be
+expressed statically. Use `:on_unsupported`:
+
+```elixir
+Peri.to_json_schema(schema, on_unsupported: :raise)
+```
+
+- `:omit` (default) — emit `%{}` (true schema)
+- `:true_schema` — same as `:omit`
+- `:raise` — raise `Peri.JSONSchema.Encoder.UnsupportedTypeError`
+
+## Decoding
+
+```elixir
+{:ok, schema} =
+  Peri.from_json_schema(%{
+    "type" => "object",
+    "properties" => %{"name" => %{"type" => "string"}},
+    "required" => ["name"]
+  })
+
+# schema => %{name: {:required, :string}}
+```
+
+`from_json_schema/1` runs `Peri.validate_schema/1` on the result, returning
+`{:error, errors}` if the JSON Schema cannot be expressed as a valid Peri
+schema.

--- a/test/json_schema_test.exs
+++ b/test/json_schema_test.exs
@@ -200,6 +200,23 @@ defmodule Peri.JSONSchemaTest do
       json = %{"type" => "string", "pattern" => "^foo"}
       assert {:ok, {:string, {:regex, %Regex{}}}} = Peri.from_json_schema(json)
     end
+
+    test "invalid regex pattern is dropped, not raised" do
+      json = %{"type" => "string", "pattern" => "["}
+      assert {:ok, :string} = Peri.from_json_schema(json)
+    end
+
+    test "non-existing atom keys fall back to string keys" do
+      key = "this_atom_does_not_exist_#{System.unique_integer([:positive])}"
+
+      json = %{
+        "type" => "object",
+        "properties" => %{key => %{"type" => "string"}}
+      }
+
+      assert {:ok, schema} = Peri.from_json_schema(json)
+      assert schema[key] == :string
+    end
   end
 
   describe "round-trip" do

--- a/test/json_schema_test.exs
+++ b/test/json_schema_test.exs
@@ -1,0 +1,230 @@
+defmodule Peri.JSONSchemaTest do
+  use ExUnit.Case, async: true
+
+  alias Peri.JSONSchema.Encoder.UnsupportedTypeError
+
+  describe "to_json_schema/2 — basic types" do
+    test "primitive types" do
+      assert Peri.to_json_schema(:string) == %{"type" => "string"}
+      assert Peri.to_json_schema(:integer) == %{"type" => "integer"}
+      assert Peri.to_json_schema(:float) == %{"type" => "number"}
+      assert Peri.to_json_schema(:boolean) == %{"type" => "boolean"}
+      assert Peri.to_json_schema(:any) == %{}
+      assert Peri.to_json_schema(nil) == %{"type" => "null"}
+    end
+
+    test "time types" do
+      assert Peri.to_json_schema(:date) == %{"type" => "string", "format" => "date"}
+      assert Peri.to_json_schema(:datetime) == %{"type" => "string", "format" => "date-time"}
+    end
+
+    test "literals and enums" do
+      assert Peri.to_json_schema({:literal, :ok}) == %{"const" => :ok}
+      assert Peri.to_json_schema({:enum, [:a, :b]}) == %{"enum" => [:a, :b]}
+    end
+  end
+
+  describe "to_json_schema/2 — objects and required" do
+    test "object with mixed required and optional" do
+      schema = %{name: {:required, :string}, age: :integer}
+      json = Peri.to_json_schema(schema)
+
+      assert json["type"] == "object"
+      assert json["properties"]["name"] == %{"type" => "string"}
+      assert json["properties"]["age"] == %{"type" => "integer"}
+      assert json["required"] == ["name"]
+    end
+
+    test "object with no required omits required key" do
+      assert Peri.to_json_schema(%{name: :string}) ==
+               %{"type" => "object", "properties" => %{"name" => %{"type" => "string"}}}
+    end
+
+    test "nested objects" do
+      schema = %{user: %{name: {:required, :string}}}
+      json = Peri.to_json_schema(schema)
+      assert json["properties"]["user"]["type"] == "object"
+      assert json["properties"]["user"]["required"] == ["name"]
+    end
+  end
+
+  describe "to_json_schema/2 — collections" do
+    test "list" do
+      assert Peri.to_json_schema({:list, :integer}) ==
+               %{"type" => "array", "items" => %{"type" => "integer"}}
+    end
+
+    test "map with value type" do
+      assert Peri.to_json_schema({:map, :string}) ==
+               %{"type" => "object", "additionalProperties" => %{"type" => "string"}}
+    end
+
+    test "tuple as fixed-length array" do
+      assert Peri.to_json_schema({:tuple, [:string, :integer]}) ==
+               %{
+                 "type" => "array",
+                 "items" => [%{"type" => "string"}, %{"type" => "integer"}],
+                 "minItems" => 2,
+                 "maxItems" => 2
+               }
+    end
+  end
+
+  describe "to_json_schema/2 — constraints" do
+    test "integer constraints" do
+      assert Peri.to_json_schema({:integer, gte: 0}) ==
+               %{"type" => "integer", "minimum" => 0}
+
+      assert Peri.to_json_schema({:integer, gt: 0}) ==
+               %{"type" => "integer", "exclusiveMinimum" => 0}
+
+      assert Peri.to_json_schema({:integer, [gte: 0, lte: 100]}) ==
+               %{"type" => "integer", "minimum" => 0, "maximum" => 100}
+    end
+
+    test "string regex" do
+      assert Peri.to_json_schema({:string, {:regex, ~r/^foo/}}) ==
+               %{"type" => "string", "pattern" => "^foo"}
+    end
+
+    test "string min/max" do
+      assert Peri.to_json_schema({:string, [min: 3, max: 10]}) ==
+               %{"type" => "string", "minLength" => 3, "maxLength" => 10}
+    end
+  end
+
+  describe "to_json_schema/2 — unions" do
+    test "either → oneOf" do
+      assert Peri.to_json_schema({:either, {:string, :integer}}) ==
+               %{"oneOf" => [%{"type" => "string"}, %{"type" => "integer"}]}
+    end
+
+    test "oneof → oneOf" do
+      assert Peri.to_json_schema({:oneof, [:string, :integer, :boolean]}) ==
+               %{
+                 "oneOf" => [
+                   %{"type" => "string"},
+                   %{"type" => "integer"},
+                   %{"type" => "boolean"}
+                 ]
+               }
+    end
+  end
+
+  describe "to_json_schema/2 — defaults and meta" do
+    test "default surfaces under \"default\"" do
+      assert Peri.to_json_schema({:string, {:default, "x"}}) ==
+               %{"type" => "string", "default" => "x"}
+    end
+
+    test "meta wrapper attaches title/description/examples/deprecated" do
+      schema = %{
+        email:
+          {:meta, {:required, :string},
+           title: "Email", description: "Login", example: "a@b.io", deprecated: false}
+      }
+
+      json = Peri.to_json_schema(schema)
+      prop = json["properties"]["email"]
+      assert prop["type"] == "string"
+      assert prop["title"] == "Email"
+      assert prop["description"] == "Login"
+      assert prop["examples"] == ["a@b.io"]
+      assert prop["deprecated"] == false
+      assert json["required"] == ["email"]
+    end
+  end
+
+  describe "to_json_schema/2 — :on_unsupported" do
+    test ":omit (default) emits empty schema for custom" do
+      schema = %{f: {:custom, fn _ -> :ok end}}
+      assert Peri.to_json_schema(schema)["properties"]["f"] == %{}
+    end
+
+    test ":raise raises on dependent" do
+      schema = %{f: {:dependent, fn _ -> {:ok, :string} end}}
+
+      assert_raise UnsupportedTypeError, fn ->
+        Peri.to_json_schema(schema, on_unsupported: :raise)
+      end
+    end
+  end
+
+  describe "from_json_schema/1" do
+    test "object with required" do
+      json = %{
+        "type" => "object",
+        "properties" => %{
+          "name" => %{"type" => "string"},
+          "age" => %{"type" => "integer"}
+        },
+        "required" => ["name"]
+      }
+
+      assert {:ok, schema} = Peri.from_json_schema(json)
+      assert schema[:name] == {:required, :string}
+      assert schema[:age] == :integer
+    end
+
+    test "primitives" do
+      assert {:ok, :string} = Peri.from_json_schema(%{"type" => "string"})
+      assert {:ok, :integer} = Peri.from_json_schema(%{"type" => "integer"})
+      assert {:ok, :boolean} = Peri.from_json_schema(%{"type" => "boolean"})
+      assert {:ok, {:literal, nil}} = Peri.from_json_schema(%{"type" => "null"})
+    end
+
+    test "const → literal" do
+      assert {:ok, {:literal, "x"}} = Peri.from_json_schema(%{"const" => "x"})
+    end
+
+    test "enum" do
+      assert {:ok, {:enum, [1, 2, 3]}} = Peri.from_json_schema(%{"enum" => [1, 2, 3]})
+    end
+
+    test "array" do
+      assert {:ok, {:list, :string}} =
+               Peri.from_json_schema(%{"type" => "array", "items" => %{"type" => "string"}})
+    end
+
+    test "oneOf with two → either" do
+      json = %{"oneOf" => [%{"type" => "string"}, %{"type" => "integer"}]}
+      assert {:ok, {:either, {:string, :integer}}} = Peri.from_json_schema(json)
+    end
+
+    test "integer minimum → gte" do
+      json = %{"type" => "integer", "minimum" => 0}
+      assert {:ok, {:integer, {:gte, 0}}} = Peri.from_json_schema(json)
+    end
+
+    test "string pattern → regex" do
+      json = %{"type" => "string", "pattern" => "^foo"}
+      assert {:ok, {:string, {:regex, %Regex{}}}} = Peri.from_json_schema(json)
+    end
+  end
+
+  describe "round-trip" do
+    test "primitives" do
+      for type <- [:string, :integer, :float, :boolean] do
+        assert {:ok, ^type} = type |> Peri.to_json_schema() |> Peri.from_json_schema()
+      end
+    end
+
+    test "object with required" do
+      schema = %{name: {:required, :string}, age: :integer}
+      json = Peri.to_json_schema(schema)
+      assert {:ok, decoded} = Peri.from_json_schema(json)
+      assert decoded[:name] == {:required, :string}
+      assert decoded[:age] == :integer
+    end
+
+    test "list of strings" do
+      assert {:ok, {:list, :string}} =
+               {:list, :string} |> Peri.to_json_schema() |> Peri.from_json_schema()
+    end
+
+    test "integer with gte" do
+      assert {:ok, {:integer, {:gte, 0}}} =
+               {:integer, gte: 0} |> Peri.to_json_schema() |> Peri.from_json_schema()
+    end
+  end
+end


### PR DESCRIPTION
**Description**
Adds `Peri.to_json_schema/2` and `Peri.from_json_schema/1` backed by `Peri.JSONSchema.Encoder` and `Peri.JSONSchema.Decoder`. Lifts the bidirectional converters from anubis-mcp, drops the MCP-specific `:mcp_field` plumbing, and reads Phase 1's `{:meta, type, opts}` annotations into JSON Schema annotation keywords (`title`, `description`, `examples`, `deprecated`).

Dynamic Peri types (`:dependent`, `:cond`, `:custom`) cannot be expressed statically. The encoder accepts `:on_unsupported` (`:omit` default | `:true_schema` | `:raise`).

**Related Issues**
Phase 2 of the malli-inspired feature plan. Built on Phase 1 (#47).

**Type of Change**
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
- New modules: `Peri.JSONSchema.Encoder`, `Peri.JSONSchema.Decoder`. `Peri.to_json_schema` / `Peri.from_json_schema` delegate one hop directly — no extra facade module.
- Round-trip coverage for primitives, lists, objects with required, and integer constraints.
- Doc page `pages/json_schema.md` covers the type mapping table, metadata mapping, and the `:on_unsupported` strategy.
- Coordination follow-up: anubis-mcp can drop its in-tree converters and depend on `Peri.JSONSchema` once this lands.