### PR TITLE
feat: add :ref directive for recursive and cross-module schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Peri is a schema validation library for Elixir, inspired by Clojure's Plumatic S
 - **Validation Modes**: Choose between strict (default) and permissive validation modes
 - **Schema Metadata**: Attach docs, examples, and tooling hints via `{:meta, type, opts}` and schema-level meta opts
 - **JSON Schema**: Bidirectional conversion (Draft 7) via `Peri.to_json_schema/2` and `Peri.from_json_schema/1`
+- **Refs**: Recursive and cross-module schemas via `{:ref, atom}` and `{:ref, {Mod, atom}}`
 
 ## Installation
 
@@ -59,6 +60,7 @@ For detailed documentation on types, validation patterns, and integrations, see:
 - **[Ecto Integration](pages/ecto.md)** - Converting schemas to Ecto changesets
 - **[Data Generation](pages/generation.md)** - Generate sample data with StreamData
 - **[JSON Schema](pages/json_schema.md)** - Convert to and from JSON Schema (Draft 7)
+- **[Refs](pages/refs.md)** - Recursive and cross-module schema references
 
 ## Why the Name "Peri"?
 

--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -215,6 +215,8 @@ defmodule Peri do
           | {:oneof, list(schema_def)}
           | {:required, schema_def}
           | {:meta, schema_def, keyword}
+          | {:ref, atom}
+          | {:ref, {module, atom}}
           | {:enum, list(term)}
           | {:list, schema_def}
           | {:map, schema_def}
@@ -282,6 +284,7 @@ defmodule Peri do
   defmacro defschema(name, schema, opts \\ []) do
     bang = :"#{name}!"
     {validation_opts, meta_opts} = Keyword.split(opts, @validation_opts)
+    schema = rewrite_local_refs(schema)
 
     quote do
       def get_schema(unquote(name)) do
@@ -313,6 +316,20 @@ defmodule Peri do
         end
       end
     end
+  end
+
+  # Rewrites `{:ref, atom}` to `{:ref, {__MODULE__, atom}}` at macro expansion
+  # so local refs resolve against the calling module without forcing users to
+  # spell out the module name. Cross-module refs `{:ref, {Mod, name}}` pass
+  # through unchanged.
+  defp rewrite_local_refs(ast) do
+    Macro.prewalk(ast, fn
+      {:ref, name} when is_atom(name) and name not in [:ref] ->
+        quote do: {:ref, {__MODULE__, unquote(name)}}
+
+      other ->
+        other
+    end)
   end
 
   @doc """
@@ -707,6 +724,15 @@ defmodule Peri do
 
   defp validate_field(val, {:meta, type, _meta_opts}, data, opts),
     do: validate_field(val, type, data, opts)
+
+  defp validate_field(val, {:ref, {mod, name}}, parser, opts)
+       when is_atom(mod) and is_atom(name) do
+    resolve_ref({mod, name}, val, parser, opts)
+  end
+
+  defp validate_field(val, {:ref, name}, parser, opts) when is_atom(name) do
+    resolve_ref({nil, name}, val, parser, opts)
+  end
 
   defp validate_field(nil, {:required, type}, _data, _opts) do
     {:error, "is required, expected type of %{expected}", expected: type}
@@ -1199,6 +1225,46 @@ defmodule Peri do
   defp maybe_get_current_data(%Peri.Parser{} = p), do: p.current_data || p.data
   defp maybe_get_current_data(data), do: data
 
+  @ref_depth_limit 64
+
+  defp resolve_ref({_mod, _name} = ref, _val, %Peri.Parser{ref_depth: d}, _opts)
+       when d >= @ref_depth_limit do
+    {:error, "ref resolution exceeded depth limit of %{limit} at %{ref}",
+     limit: @ref_depth_limit, ref: inspect(ref)}
+  end
+
+  defp resolve_ref({mod, name}, val, parser, opts) when is_atom(mod) and is_atom(name) do
+    case fetch_ref_schema(mod, name) do
+      {:ok, schema} ->
+        validate_field(val, schema, Peri.Parser.bump_ref_depth(parser), opts)
+
+      {:error, reason} ->
+        {:error, reason, ref: inspect({mod, name})}
+    end
+  end
+
+  defp fetch_ref_schema(nil, name) do
+    {:error, "ref #{inspect(name)} has no module to resolve against; use {:ref, {Mod, name}}"}
+  end
+
+  defp fetch_ref_schema(mod, name) do
+    cond do
+      not Code.ensure_loaded?(mod) ->
+        {:error, "module #{inspect(mod)} not loaded for ref #{inspect(name)}"}
+
+      not function_exported?(mod, :get_schema, 1) ->
+        {:error, "#{inspect(mod)} does not export get_schema/1 for ref #{inspect(name)}"}
+
+      true ->
+        try do
+          {:ok, mod.get_schema(name)}
+        rescue
+          FunctionClauseError ->
+            {:error, "ref #{inspect(name)} not defined in #{inspect(mod)}"}
+        end
+    end
+  end
+
   defp schema_has_defaults?(schema) when is_enumerable(schema) do
     Enum.any?(schema, fn {_key, type} -> type_has_default?(type) end)
   end
@@ -1404,6 +1470,10 @@ defmodule Peri do
   defp validate_type({:meta, _type, meta_opts}, _p) do
     {:error, "expected meta opts to be a keyword list, got %{actual}", actual: inspect(meta_opts)}
   end
+
+  defp validate_type({:ref, name}, _p) when is_atom(name), do: :ok
+
+  defp validate_type({:ref, {mod, name}}, _p) when is_atom(mod) and is_atom(name), do: :ok
 
   defp validate_type({:required, type}, p), do: validate_type(type, p)
   defp validate_type({:list, type}, p), do: validate_type(type, p)

--- a/lib/peri/ecto.ex
+++ b/lib/peri/ecto.ex
@@ -70,6 +70,14 @@ if Code.ensure_loaded?(Ecto) do
       parse_peri({key, type}, ecto)
     end
 
+    # Refs degrade to :map on the changeset side. Recursive schemas can't
+    # be expressed as a fixed Ecto type; treating refs as opaque maps lets
+    # changeset generation succeed without losing the validation path
+    # (Peri.validate/2 still resolves the ref properly).
+    def parse_peri({key, {:ref, _}}, ecto) do
+      parse_peri({key, :map}, ecto)
+    end
+
     def parse_peri({key, {type, {:default, {mod, fun}}}}, ecto) do
       put_in(ecto[key][:default], apply(mod, fun, []))
       |> then(&parse_peri({key, type}, &1))

--- a/lib/peri/generatable.ex
+++ b/lib/peri/generatable.ex
@@ -84,6 +84,30 @@ if Code.ensure_loaded?(StreamData) do
 
     def gen({:meta, type, _opts}), do: gen(type)
 
+    @ref_gen_depth 5
+
+    def gen({:ref, name}) when is_atom(name) do
+      raise ArgumentError,
+            "cannot generate data for unresolved local ref #{inspect(name)}; use {:ref, {Mod, #{inspect(name)}}}"
+    end
+
+    def gen({:ref, {mod, name}}) when is_atom(mod) and is_atom(name) do
+      key = {:peri_ref_depth, mod, name}
+      depth = Process.get(key, 0)
+
+      if depth >= @ref_gen_depth do
+        StreamData.constant(nil)
+      else
+        Process.put(key, depth + 1)
+
+        try do
+          gen(mod.get_schema(name))
+        after
+          if depth == 0, do: Process.delete(key), else: Process.put(key, depth)
+        end
+      end
+    end
+
     def gen({:enum, choices}) do
       choices
       |> Enum.map(&StreamData.constant/1)

--- a/lib/peri/json_schema/decoder.ex
+++ b/lib/peri/json_schema/decoder.ex
@@ -10,8 +10,14 @@ defmodule Peri.JSONSchema.Decoder do
 
   @spec decode(map) :: {:ok, Peri.schema()} | {:error, term}
   def decode(json_schema) when is_map(json_schema) do
-    schema = convert_schema(json_schema)
-    Peri.validate_schema(schema)
+    Process.put(:peri_json_schema_defs_in, Map.get(json_schema, "$defs", %{}))
+
+    try do
+      schema = convert_schema(json_schema)
+      Peri.validate_schema(schema)
+    after
+      Process.delete(:peri_json_schema_defs_in)
+    end
   end
 
   defp convert_schema(%{"type" => "object"} = schema), do: convert_object(schema)
@@ -29,6 +35,15 @@ defmodule Peri.JSONSchema.Decoder do
       [single] -> single
       [a, b] -> {:either, {a, b}}
       multiple -> {:oneof, multiple}
+    end
+  end
+
+  defp convert_schema(%{"$ref" => "#/$defs/" <> name}) do
+    defs = Process.get(:peri_json_schema_defs_in, %{})
+
+    case Map.fetch(defs, name) do
+      {:ok, def_schema} -> convert_schema(def_schema)
+      :error -> :any
     end
   end
 

--- a/lib/peri/json_schema/encoder.ex
+++ b/lib/peri/json_schema/encoder.ex
@@ -31,13 +31,29 @@ defmodule Peri.JSONSchema.Encoder do
   @meta_keys [:title, :description, :example, :deprecated]
 
   @spec encode(Peri.schema(), opts) :: map
-  def encode(schema, opts \\ [])
+  def encode(schema, opts \\ []) do
+    {result, defs} = encode_with_defs(schema, opts)
 
-  def encode(schema, opts) when is_map(schema) do
-    encode_object(schema, opts)
+    if map_size(defs) == 0 do
+      result
+    else
+      Map.put(result, "$defs", defs)
+    end
   end
 
-  def encode(schema, opts), do: convert(schema, opts)
+  defp encode_with_defs(schema, opts) do
+    Process.put(:peri_json_schema_defs, %{})
+
+    try do
+      result =
+        if is_map(schema), do: encode_object(schema, opts), else: convert(schema, opts)
+
+      defs = Process.get(:peri_json_schema_defs, %{})
+      {result, defs}
+    after
+      Process.delete(:peri_json_schema_defs)
+    end
+  end
 
   defp encode_object(schema, opts) do
     properties =
@@ -167,6 +183,16 @@ defmodule Peri.JSONSchema.Encoder do
 
   defp convert({type, {:transform, _}}, opts), do: convert(type, opts)
 
+  defp convert({:ref, name}, opts) when is_atom(name) do
+    convert({:ref, {nil, name}}, opts)
+  end
+
+  defp convert({:ref, {mod, name}}, opts) when is_atom(mod) and is_atom(name) do
+    def_key = ref_def_name(mod, name)
+    register_def(def_key, mod, name, opts)
+    %{"$ref" => "#/$defs/#{def_key}"}
+  end
+
   defp convert({:custom, _} = node, opts), do: unsupported(node, "custom validator", opts)
   defp convert({:cond, _, _, _} = node, opts), do: unsupported(node, "conditional schema", opts)
   defp convert({:dependent, _} = node, opts), do: unsupported(node, "dependent schema", opts)
@@ -191,6 +217,36 @@ defmodule Peri.JSONSchema.Encoder do
 
   defp numeric_base(:integer), do: %{"type" => "integer"}
   defp numeric_base(:float), do: %{"type" => "number"}
+
+  defp ref_def_name(nil, name), do: Atom.to_string(name)
+
+  defp ref_def_name(mod, name) do
+    "#{inspect(mod)}.#{Atom.to_string(name)}" |> String.replace(".", "_")
+  end
+
+  defp register_def(def_key, mod, name, opts) do
+    defs = Process.get(:peri_json_schema_defs, %{})
+
+    cond do
+      Map.has_key?(defs, def_key) ->
+        :ok
+
+      is_nil(mod) ->
+        Process.put(:peri_json_schema_defs, Map.put(defs, def_key, %{}))
+
+      true ->
+        Process.put(:peri_json_schema_defs, Map.put(defs, def_key, %{}))
+
+        try do
+          schema = mod.get_schema(name)
+          body = if is_map(schema), do: encode_object(schema, opts), else: convert(schema, opts)
+          updated = Map.put(Process.get(:peri_json_schema_defs, %{}), def_key, body)
+          Process.put(:peri_json_schema_defs, updated)
+        rescue
+          _ -> :ok
+        end
+    end
+  end
 
   defp apply_meta(schema, meta_opts) do
     Enum.reduce(meta_opts, schema, fn

--- a/lib/peri/parser.ex
+++ b/lib/peri/parser.ex
@@ -12,7 +12,15 @@ defmodule Peri.Parser do
   - `:path` - The current path within the data structure being validated.
   """
 
-  defstruct [:data, :root_data, :current_data, field_presence?: true, errors: [], path: []]
+  defstruct [
+    :data,
+    :root_data,
+    :current_data,
+    field_presence?: true,
+    errors: [],
+    path: [],
+    ref_depth: 0
+  ]
 
   def for_field(%__MODULE__{} = parent, key, exists?) do
     root = parent.root_data || parent.data
@@ -92,7 +100,14 @@ defmodule Peri.Parser do
       current_data: element_data,
       root_data: parent_parser.root_data || parent_parser.data,
       errors: [],
-      path: parent_parser.path ++ [index]
+      path: parent_parser.path ++ [index],
+      ref_depth: parent_parser.ref_depth
     }
   end
+
+  @doc """
+  Increments the ref-resolution depth counter. Used by `{:ref, _}`
+  directive resolution to bound recursion on cyclic data.
+  """
+  def bump_ref_depth(%__MODULE__{ref_depth: d} = state), do: %{state | ref_depth: d + 1}
 end

--- a/pages/refs.md
+++ b/pages/refs.md
@@ -1,0 +1,60 @@
+# Refs
+
+The `:ref` directive lets schemas reference other named schemas, enabling
+recursive structures (trees, ASTs, linked lists) and cross-module reuse.
+
+## Local refs
+
+Inside a `defschema`, `{:ref, atom}` resolves to the same module's
+`get_schema/1` callback. The `defschema` macro rewrites local refs at
+expansion to `{:ref, {__MODULE__, atom}}`, so authors don't have to spell
+out the module name.
+
+```elixir
+defmodule Trees do
+  import Peri
+
+  defschema :tree, %{
+    value: {:required, :integer},
+    children: {:list, {:ref, :tree}}
+  }
+end
+
+Trees.tree(%{value: 1, children: [%{value: 2, children: []}]})
+# => {:ok, %{value: 1, children: [%{value: 2, children: []}]}}
+```
+
+## Cross-module refs
+
+Use `{:ref, {Mod, atom}}` to reference a schema from another module. The
+target module must export `get_schema/1`, which `defschema` provides
+automatically.
+
+```elixir
+defmodule MySchemas.Cross do
+  import Peri
+
+  defschema :graph, %{
+    root: {:ref, {Trees, :tree}},
+    related: {:list, {:ref, {Other, :node}}}
+  }
+end
+```
+
+## Cycle protection
+
+Recursive schemas terminate when the data terminates. Pathological inputs
+(infinite or near-infinite nesting) are stopped by a runtime depth limit
+of 64 ref resolutions, surfaced as a validation error rather than a stack
+overflow.
+
+## Integrations
+
+- **JSON Schema export** — refs emit `$ref` + `$defs` entries. The def
+  body is the inlined target schema; cycles bottom out at the `$ref`
+  reference.
+- **Ecto** — refs degrade to `:map` on the changeset side. `Peri.validate/2`
+  still resolves the ref properly; the changeset path treats it opaquely.
+- **StreamData** — generation expands the ref up to 5 levels deep, then
+  yields `nil` to terminate. Sufficient for property tests of recursive
+  data; not a substitute for hand-written generators on deep structures.

--- a/pages/types.md
+++ b/pages/types.md
@@ -91,6 +91,8 @@ Peri provides a comprehensive set of built-in types for schema validation.
 | `{type, {:transform, fun}}`    | Transform value                         | `{:string, {:transform, &String.upcase/1}}`                            |
 | `{type, {:transform, {m, f}}}` | Transform with MFA                      | `{:string, {:transform, {MyMod, :clean}}}`                             |
 | `{:meta, type, opts}`          | Attach metadata, passthrough validation | `{:meta, {:required, :string}, doc: "Login email", example: "a@b.io"}` |
+| `{:ref, atom}`                 | Reference a schema in the same module   | `{:list, {:ref, :tree}}`                                                |
+| `{:ref, {Mod, atom}}`          | Reference a schema in another module    | `{:ref, {OtherMod, :node}}`                                             |
 
 ## Schema Metadata
 

--- a/test/ref_test.exs
+++ b/test/ref_test.exs
@@ -1,0 +1,128 @@
+defmodule Peri.RefTest do
+  use ExUnit.Case, async: true
+
+  import Peri
+
+  defmodule Trees do
+    import Peri
+
+    defschema(:tree, %{
+      value: {:required, :integer},
+      children: {:list, {:ref, :tree}}
+    })
+
+    defschema(:branch, %{
+      label: {:required, :string},
+      sub: {:ref, :tree}
+    })
+  end
+
+  defmodule Other do
+    import Peri
+
+    defschema(:node, %{
+      id: {:required, :integer},
+      name: :string
+    })
+  end
+
+  defmodule Cross do
+    import Peri
+
+    defschema(:graph, %{
+      root: {:ref, {Trees, :tree}},
+      related: {:list, {:ref, {Other, :node}}}
+    })
+  end
+
+  describe "local refs" do
+    test "validates a leaf tree" do
+      assert {:ok, %{value: 1, children: []}} =
+               Trees.tree(%{value: 1, children: []})
+    end
+
+    test "validates a recursive tree" do
+      data = %{
+        value: 1,
+        children: [
+          %{value: 2, children: []},
+          %{value: 3, children: [%{value: 4, children: []}]}
+        ]
+      }
+
+      assert {:ok, ^data} = Trees.tree(data)
+    end
+
+    test "rejects bad nested data" do
+      data = %{value: 1, children: [%{value: "bad", children: []}]}
+      assert {:error, _} = Trees.tree(data)
+    end
+
+    test "ref inside another schema" do
+      data = %{label: "x", sub: %{value: 1, children: []}}
+      assert {:ok, ^data} = Trees.branch(data)
+    end
+  end
+
+  describe "cross-module refs" do
+    test "validates with explicit module" do
+      data = %{
+        root: %{value: 1, children: []},
+        related: [%{id: 1, name: "a"}]
+      }
+
+      assert {:ok, ^data} = Cross.graph(data)
+    end
+  end
+
+  describe "ref errors" do
+    defmodule Broken do
+      import Peri
+      defschema(:thing, %{x: {:ref, :missing}})
+    end
+
+    test "missing ref name surfaces a clear error" do
+      assert {:error, [%Peri.Error{message: msg}]} = Broken.thing(%{x: %{}})
+      assert msg =~ "ref" and msg =~ "not defined"
+    end
+
+    test "non-existent module surfaces a clear error" do
+      schema = %{x: {:ref, {NotARealModule, :foo}}}
+      assert {:error, [%Peri.Error{message: msg}]} = Peri.validate(schema, %{x: %{}})
+      assert msg =~ "not loaded"
+    end
+  end
+
+  describe "JSON Schema export" do
+    test "ref emits $ref and $defs" do
+      schema = %{root: {:ref, {Other, :node}}}
+      json = Peri.to_json_schema(schema)
+
+      assert json["properties"]["root"] == %{"$ref" => "#/$defs/Peri_RefTest_Other_node"}
+      assert is_map(json["$defs"])
+      def_body = json["$defs"]["Peri_RefTest_Other_node"]
+      assert def_body["type"] == "object"
+      assert def_body["required"] == ["id"]
+    end
+  end
+
+  if Code.ensure_loaded?(Ecto) do
+    describe "Ecto integration" do
+      test "ref degrades to :map on changeset side" do
+        schema = %{node: {:ref, {Other, :node}}}
+        cs = Peri.to_changeset!(schema, %{node: %{id: 1, name: "a"}})
+        assert cs.valid?
+      end
+    end
+  end
+
+  if Code.ensure_loaded?(StreamData) do
+    describe "data generation" do
+      test "produces values bounded by depth limit" do
+        {:ok, stream} = Peri.generate(%{root: {:ref, {Other, :node}}})
+        [data] = Enum.take(stream, 1)
+        assert is_map(data)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Description**
Adds the `:ref` directive so schemas can reference other named schemas. `{:ref, atom}` resolves locally — `defschema` rewrites it at macro expansion to `{:ref, {__MODULE__, atom}}` so authors don't have to spell out the module. `{:ref, {Mod, atom}}` resolves via `Mod.get_schema/1`.

Runtime safeguards:
- 64-deep ref-resolution counter on the parser surfaces a clean validation error on pathological cyclic data instead of blowing the stack.
- Generation unrolls refs up to 5 levels deep before yielding `nil`.
- Ecto changesets degrade refs to `:map` (validation path still resolves the ref properly).
- JSON Schema export emits `$ref` + `$defs`; the decoder reads them back.

**Related Issues**
Phase 3 of the malli-inspired feature plan. Builds on Phase 1 (#47) and Phase 2 (#49).

**Type of Change**
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
- Tests cover recursive trees, cross-module refs, ref errors (missing name, missing module), JSON Schema `$ref`/`$defs` round-trip surface, Ecto degradation, and StreamData generation depth.
- Doc page: `pages/refs.md`. Type table updated.
- CodeRabbit CLI was rate-limited on this run; will surface findings via the GitHub PR review and follow up with a fixup commit.