### PR TITLE
feat: add :multi directive for tagged unions

### DIFF
--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -217,6 +217,7 @@ defmodule Peri do
           | {:meta, schema_def, keyword}
           | {:ref, atom}
           | {:ref, {module, atom}}
+          | {:multi, atom, %{optional(term) => schema_def}}
           | {:enum, list(term)}
           | {:list, schema_def}
           | {:map, schema_def}
@@ -732,6 +733,11 @@ defmodule Peri do
 
   defp validate_field(val, {:ref, name}, parser, opts) when is_atom(name) do
     resolve_ref({nil, name}, val, parser, opts)
+  end
+
+  defp validate_field(val, {:multi, field, branches}, parser, opts)
+       when is_atom(field) and is_map(branches) do
+    dispatch_multi(val, field, branches, parser, opts)
   end
 
   defp validate_field(nil, {:required, type}, _data, _opts) do
@@ -1265,6 +1271,43 @@ defmodule Peri do
     end
   end
 
+  defp dispatch_multi(val, field, branches, parser, opts) when is_map(val) or is_list(val) do
+    with {:ok, tag} <- fetch_dispatch_value(val, field),
+         {:ok, branch} <- fetch_branch(branches, tag, field) do
+      validate_field(val, branch, parser, opts)
+    end
+  end
+
+  defp dispatch_multi(val, _field, _branches, _parser, _opts) do
+    {:error, "expected a map or keyword list for :multi dispatch, got %{actual}",
+     actual: inspect(val)}
+  end
+
+  defp fetch_dispatch_value(val, field) when is_map(val) do
+    cond do
+      Map.has_key?(val, field) -> {:ok, Map.get(val, field)}
+      Map.has_key?(val, Atom.to_string(field)) -> {:ok, Map.get(val, Atom.to_string(field))}
+      true -> {:error, "missing :multi dispatch field %{field}", [field: field]}
+    end
+  end
+
+  defp fetch_dispatch_value(val, field) when is_list(val) do
+    if Keyword.has_key?(val, field),
+      do: {:ok, Keyword.get(val, field)},
+      else: {:error, "missing :multi dispatch field %{field}", [field: field]}
+  end
+
+  defp fetch_branch(branches, tag, field) do
+    case Map.fetch(branches, tag) do
+      {:ok, branch} ->
+        {:ok, branch}
+
+      :error ->
+        {:error, "no :multi branch matches dispatch %{field}=%{tag}; expected one of %{tags}",
+         field: field, tag: inspect(tag), tags: inspect(Map.keys(branches))}
+    end
+  end
+
   defp schema_has_defaults?(schema) when is_enumerable(schema) do
     Enum.any?(schema, fn {_key, type} -> type_has_default?(type) end)
   end
@@ -1474,6 +1517,25 @@ defmodule Peri do
   defp validate_type({:ref, name}, _p) when is_atom(name), do: :ok
 
   defp validate_type({:ref, {mod, name}}, _p) when is_atom(mod) and is_atom(name), do: :ok
+
+  defp validate_type({:multi, field, branches}, p)
+       when is_atom(field) and is_map(branches) do
+    Enum.reduce_while(branches, :ok, fn {_tag, branch}, :ok ->
+      case validate_type(branch, p) do
+        :ok -> {:cont, :ok}
+        err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp validate_type({:multi, field, _branches}, _p) when not is_atom(field) do
+    {:error, "expected :multi dispatch field to be an atom, got %{actual}",
+     actual: inspect(field)}
+  end
+
+  defp validate_type({:multi, _field, branches}, _p) when not is_map(branches) do
+    {:error, "expected :multi branches to be a map, got %{actual}", actual: inspect(branches)}
+  end
 
   defp validate_type({:required, type}, p), do: validate_type(type, p)
   defp validate_type({:list, type}, p), do: validate_type(type, p)

--- a/lib/peri/generatable.ex
+++ b/lib/peri/generatable.ex
@@ -86,6 +86,16 @@ if Code.ensure_loaded?(StreamData) do
 
     @ref_gen_depth 5
 
+    def gen({:multi, field, branches}) when is_atom(field) and is_map(branches) do
+      branches
+      |> Enum.map(fn {tag, branch} ->
+        StreamData.bind(gen(branch), fn val ->
+          StreamData.constant(merge_dispatch(val, field, tag))
+        end)
+      end)
+      |> StreamData.one_of()
+    end
+
     def gen({:ref, name}) when is_atom(name) do
       raise ArgumentError,
             "cannot generate data for unresolved local ref #{inspect(name)}; use {:ref, {Mod, #{inspect(name)}}}"
@@ -256,5 +266,9 @@ if Code.ensure_loaded?(StreamData) do
       end
       |> StreamData.fixed_map()
     end
+
+    defp merge_dispatch(val, field, tag) when is_map(val), do: Map.put(val, field, tag)
+    defp merge_dispatch(val, field, tag) when is_list(val), do: Keyword.put(val, field, tag)
+    defp merge_dispatch(val, _field, _tag), do: val
   end
 end

--- a/lib/peri/json_schema/encoder.ex
+++ b/lib/peri/json_schema/encoder.ex
@@ -183,6 +183,22 @@ defmodule Peri.JSONSchema.Encoder do
 
   defp convert({type, {:transform, _}}, opts), do: convert(type, opts)
 
+  defp convert({:multi, field, branches}, opts) when is_atom(field) and is_map(branches) do
+    branch_schemas =
+      Enum.map(branches, fn {tag, branch} ->
+        branch
+        |> convert(opts)
+        |> Map.update("properties", %{to_string(field) => %{"const" => tag}}, fn props ->
+          Map.put(props, to_string(field), %{"const" => tag})
+        end)
+      end)
+
+    %{
+      "oneOf" => branch_schemas,
+      "discriminator" => %{"propertyName" => to_string(field)}
+    }
+  end
+
   defp convert({:ref, name}, opts) when is_atom(name) do
     convert({:ref, {nil, name}}, opts)
   end

--- a/pages/types.md
+++ b/pages/types.md
@@ -93,6 +93,7 @@ Peri provides a comprehensive set of built-in types for schema validation.
 | `{:meta, type, opts}`          | Attach metadata, passthrough validation | `{:meta, {:required, :string}, doc: "Login email", example: "a@b.io"}` |
 | `{:ref, atom}`                 | Reference a schema in the same module   | `{:list, {:ref, :tree}}`                                                |
 | `{:ref, {Mod, atom}}`          | Reference a schema in another module    | `{:ref, {OtherMod, :node}}`                                             |
+| `{:multi, field, branches}`    | Tagged union dispatched on `field`      | `{:multi, :type, %{"circle" => %{r: :float}, "rect" => %{w: :float}}}`  |
 
 ## Schema Metadata
 
@@ -116,6 +117,30 @@ end
 MySchemas.__schema_meta__(:user)
 # => [title: "User", description: "Account holder"]
 ```
+
+## Tagged Unions (`:multi`)
+
+`{:multi, dispatch_field, branches}` is sugar for a discriminated union: the
+value is dispatched on `dispatch_field`, then validated against the
+matching branch schema. Errors localize to the chosen branch, so failures
+read as `shape.radius: invalid` rather than "didn't match any of N
+schemas".
+
+```elixir
+%{
+  shape: {:multi, :type, %{
+    "circle" => %{type: {:required, :string}, radius: {:required, :float}},
+    "rect"   => %{type: {:required, :string}, w: {:required, :float}, h: {:required, :float}}
+  }}
+}
+```
+
+A missing dispatch field, or a value not present in `branches`, surfaces
+as a clear validation error listing the known tags. JSON Schema export
+emits `oneOf` plus a `discriminator` annotation; data generation samples
+a branch and merges the dispatch tag into the generated value.
+
+For untagged "any of these types" semantics, use `{:oneof, types}` instead.
 
 ## Custom Validation
 

--- a/test/multi_test.exs
+++ b/test/multi_test.exs
@@ -1,0 +1,115 @@
+defmodule Peri.MultiTest do
+  use ExUnit.Case, async: true
+
+  import Peri
+
+  defschema(:shape, %{
+    shape:
+      {:multi, :type,
+       %{
+         "circle" => %{type: {:required, :string}, radius: {:required, :float}},
+         "rect" => %{type: {:required, :string}, w: {:required, :float}, h: {:required, :float}}
+       }}
+  })
+
+  describe ":multi dispatch" do
+    test "validates the matching branch" do
+      data = %{shape: %{type: "circle", radius: 1.5}}
+      assert {:ok, ^data} = shape(data)
+
+      data = %{shape: %{type: "rect", w: 2.0, h: 3.0}}
+      assert {:ok, ^data} = shape(data)
+    end
+
+    test "branch validation errors propagate with branch path" do
+      data = %{shape: %{type: "circle", radius: "not-a-float"}}
+
+      assert {:error,
+              [
+                %Peri.Error{
+                  path: [:shape],
+                  errors: [%Peri.Error{path: [:shape, :radius]}]
+                }
+              ]} = shape(data)
+    end
+
+    test "missing dispatch field surfaces clear error" do
+      data = %{shape: %{radius: 1.0}}
+      assert {:error, [%Peri.Error{message: msg}]} = shape(data)
+      assert msg =~ "missing :multi dispatch field"
+    end
+
+    test "unknown dispatch tag surfaces clear error including known tags" do
+      data = %{shape: %{type: "triangle", side: 2.0}}
+      assert {:error, [%Peri.Error{message: msg}]} = shape(data)
+      assert msg =~ "no :multi branch matches"
+      assert msg =~ "circle"
+      assert msg =~ "rect"
+    end
+  end
+
+  describe "validate_schema" do
+    test "rejects non-atom dispatch field" do
+      schema = %{x: {:multi, "type", %{"a" => %{}}}}
+      assert {:error, _} = Peri.validate_schema(schema)
+    end
+
+    test "rejects non-map branches" do
+      schema = %{x: {:multi, :type, [{"a", %{}}]}}
+      assert {:error, _} = Peri.validate_schema(schema)
+    end
+
+    test "accepts well-formed multi" do
+      schema = %{x: {:multi, :type, %{"a" => %{n: :integer}, "b" => %{s: :string}}}}
+      assert {:ok, ^schema} = Peri.validate_schema(schema)
+    end
+  end
+
+  describe "JSON Schema export" do
+    test "emits oneOf with discriminator" do
+      schema = %{
+        shape:
+          {:multi, :type,
+           %{
+             "circle" => %{r: {:required, :float}},
+             "rect" => %{w: {:required, :float}}
+           }}
+      }
+
+      json = Peri.to_json_schema(schema)
+      multi = json["properties"]["shape"]
+
+      assert is_list(multi["oneOf"])
+      assert length(multi["oneOf"]) == 2
+      assert multi["discriminator"] == %{"propertyName" => "type"}
+
+      const_tags =
+        multi["oneOf"]
+        |> Enum.map(& &1["properties"]["type"]["const"])
+        |> Enum.sort()
+
+      assert const_tags == ["circle", "rect"]
+    end
+  end
+
+  if Code.ensure_loaded?(StreamData) do
+    describe "data generation" do
+      test "samples a branch and merges dispatch tag" do
+        schema =
+          {:multi, :type,
+           %{
+             "circle" => %{r: :float},
+             "rect" => %{w: :float}
+           }}
+
+        {:ok, stream} = Peri.generate(schema)
+
+        Enum.take(stream, 20)
+        |> Enum.each(fn val ->
+          assert is_map(val)
+          assert val[:type] in ["circle", "rect"]
+        end)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Description**
Adds `{:multi, dispatch_field, branches}` as sugar for a discriminated union. The value is dispatched on `dispatch_field`, looked up against the `branches` map, and validated against the matching schema. Errors localize to the chosen branch (e.g. \`shape.radius: invalid\`) rather than degrading to a generic "didn't match any" message.

Missing dispatch fields and unknown tags surface clear errors listing the known branches. JSON Schema export emits `oneOf` plus a `discriminator` annotation; data generation samples a branch and merges the dispatch tag into the generated value.

Use `:oneof` for untagged unions; `:multi` is the right tool when there is a single discriminator field.

**Related Issues**
Phase 4 of the malli-inspired feature plan.

**Type of Change**
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

**Checklist**
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
- Implementation goes via direct `validate_field`/`validate_type` clauses instead of lowering to `:dependent`, preserving localized error context.
- Tests cover validation success, branch error propagation, missing dispatch field, unknown tag, schema-definition validation, JSON Schema export shape, and data generation.
- Doc lives inline in `pages/types.md` under "Tagged Unions" — no separate page.
- CodeRabbit CLI was rate-limited at commit time; will follow up on PR review feedback if any.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new `{:multi, field, branches}` schema form for discriminated union types, enabling validation to dynamically select the appropriate branch schema based on a discriminator field value.
  * Enhanced JSON Schema export to represent multi-branch schemas using `oneOf` with discriminator support.
  * Added data generation capability for multi-branch schemas.
  * Added comprehensive documentation for the new schema form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->