### PR TITLE
feat: per-field custom error overrides + i18n hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Peri is a schema validation library for Elixir, inspired by Clojure's Plumatic S
 - **Schema Metadata**: Attach docs, examples, and tooling hints via `{:meta, type, opts}` and schema-level meta opts
 - **JSON Schema**: Bidirectional conversion (Draft 7) via `Peri.to_json_schema/2` and `Peri.from_json_schema/1`
 - **Refs**: Recursive and cross-module schemas via `{:ref, atom}` and `{:ref, {Mod, atom}}`
+- **Custom Errors / i18n**: Per-field `error:` overrides (static or MFA) and `Peri.Error.traverse_errors/2` for Gettext-style translation
 
 ## Installation
 

--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -87,6 +87,24 @@ defmodule Peri do
   - `{:meta, type, opts}` - Attach documentation/example/description to a field; passthrough at validation
   - Nested maps for complex structures
 
+  ## Custom Error Messages
+
+  Override the default validation message per field via the `error:` opt in the
+  type's options list. Accepts either a static string or an MFA tuple
+  `{module, function, args}`. The MFA receives the `%Peri.Error{}` (with its
+  `content`) prepended to `args` and must return a string.
+
+  ```elixir
+  %{
+    age:   {:integer, gte: 18, error: "must be adult"},
+    email: {:required, :string, [error: {MyApp.Errors, :email_msg, []}]}
+  }
+  ```
+
+  For i18n / Gettext, walk the resulting errors with
+  `Peri.Error.traverse_errors/2` and translate each leaf message — see that
+  function's docs for an example.
+
   ## Schema Metadata
 
   Fields can carry metadata via the `{:meta, type, opts}` wrapper. Metadata is
@@ -755,8 +773,18 @@ defmodule Peri do
   defp validate_field(val, {:required, type}, data, opts),
     do: validate_field(val, type, data, opts)
 
+  defp validate_field(val, {:required, type, error_opts}, data, opts) when is_list(error_opts) do
+    {override, _rest} = Keyword.pop(error_opts, :error)
+
+    val
+    |> validate_field({:required, type}, data, opts)
+    |> tag_error_override(override)
+  end
+
   defp validate_field(val, {type, options}, data, opts)
        when is_type_with_multiple_options(type) and is_list(options) do
+    {override, options} = Keyword.pop(options, :error)
+
     options
     |> Enum.map(fn option -> validate_field(val, {type, option}, data, opts) end)
     |> Enum.filter(fn x -> x != :ok end)
@@ -764,6 +792,7 @@ defmodule Peri do
       [] -> :ok
       errs -> {:error, errs}
     end
+    |> tag_error_override(override)
   end
 
   defp validate_field(val, {:string, {:regex, regex}}, _data, _opts) when is_binary(val) do
@@ -1231,6 +1260,38 @@ defmodule Peri do
   defp maybe_get_current_data(%Peri.Parser{} = p), do: p.current_data || p.data
   defp maybe_get_current_data(data), do: data
 
+  defp valid_error_opt?(opts) do
+    case Keyword.fetch(opts, :error) do
+      :error -> true
+      {:ok, msg} when is_binary(msg) -> true
+      {:ok, {mod, fun, args}} when is_atom(mod) and is_atom(fun) and is_list(args) -> true
+      {:ok, _} -> false
+    end
+  end
+
+  defp tag_error_override(:ok, _), do: :ok
+  defp tag_error_override({:ok, _} = result, _), do: result
+  defp tag_error_override(result, nil), do: result
+
+  defp tag_error_override({:error, template, info}, override) when is_list(info) do
+    {:error, template, Keyword.put(info, :__error_override__, override)}
+  end
+
+  defp tag_error_override({:error, errors}, override) when is_list(errors) do
+    tagged =
+      Enum.map(errors, fn
+        {:error, template, info} when is_list(info) ->
+          {:error, template, Keyword.put(info, :__error_override__, override)}
+
+        other ->
+          other
+      end)
+
+    {:error, tagged}
+  end
+
+  defp tag_error_override(other, _), do: other
+
   @ref_depth_limit 64
 
   defp resolve_ref({_mod, _name} = ref, _val, %Peri.Parser{ref_depth: d}, _opts)
@@ -1443,6 +1504,17 @@ defmodule Peri do
 
   defp validate_type({type, options}, p)
        when is_type_with_multiple_options(type) and is_list(options) do
+    if valid_error_opt?(options) do
+      options
+      |> Keyword.delete(:error)
+      |> reduce_type_options(type, p)
+    else
+      {:error, "expected error: opt to be a string or MFA tuple, got %{actual}",
+       actual: inspect(Keyword.get(options, :error))}
+    end
+  end
+
+  defp reduce_type_options(options, type, p) do
     Enum.reduce_while(options, :ok, fn option, :ok ->
       case validate_type({type, option}, p) do
         :ok -> {:cont, :ok}
@@ -1538,6 +1610,13 @@ defmodule Peri do
   end
 
   defp validate_type({:required, type}, p), do: validate_type(type, p)
+
+  defp validate_type({:required, type, opts}, p) when is_list(opts) do
+    if Keyword.keyword?(opts) and valid_error_opt?(opts),
+      do: validate_type(type, p),
+      else: {:error, "expected error: opts to be a keyword list", []}
+  end
+
   defp validate_type({:list, type}, p), do: validate_type(type, p)
   defp validate_type({:map, type}, p), do: validate_type(type, p)
 

--- a/lib/peri/error.ex
+++ b/lib/peri/error.ex
@@ -137,10 +137,11 @@ defmodule Peri.Error do
       }
   """
   def new_single(message, context) do
+    {override, context} = pop_override(context)
     msg = format_error_message(message, context)
     content = Enum.into(context, %{})
 
-    %__MODULE__{message: msg, content: content}
+    apply_override(%__MODULE__{message: msg, content: content}, override)
   end
 
   @doc """
@@ -164,10 +165,61 @@ defmodule Peri.Error do
       }
   """
   def new_child(path, key, message, context) do
+    {override, context} = pop_override(context)
     msg = format_error_message(message, context)
     content = Enum.into(context, %{})
 
     %__MODULE__{path: path ++ [key], key: key, message: msg, content: content}
+    |> apply_override(override)
+  end
+
+  @doc false
+  def pop_override(context) when is_list(context),
+    do: Keyword.pop(context, :__error_override__)
+
+  def pop_override(context), do: {nil, context}
+
+  defp apply_override(%__MODULE__{} = err, nil), do: err
+
+  defp apply_override(%__MODULE__{} = err, msg) when is_binary(msg),
+    do: %{err | message: msg}
+
+  defp apply_override(%__MODULE__{} = err, {mod, fun, args})
+       when is_atom(mod) and is_atom(fun) and is_list(args) do
+    case apply(mod, fun, [err | args]) do
+      msg when is_binary(msg) -> %{err | message: msg}
+      _ -> err
+    end
+  end
+
+  defp apply_override(%__MODULE__{} = err, _), do: err
+
+  @doc """
+  Recursively walks an error or list of errors, applying the callback to each
+  leaf and replacing its message with the callback's return value.
+
+  Mirrors `Ecto.Changeset.traverse_errors/2`. Useful for translating template
+  strings into user-facing locale messages, e.g.
+
+      Peri.Error.traverse_errors(errors, fn err ->
+        Gettext.dgettext(MyAppWeb.Gettext, "errors", err.message, err.content || %{})
+      end)
+
+  Returns the same error shape with translated messages. Non-string callback
+  results are coerced via `to_string/1`.
+  """
+  @spec traverse_errors([t()] | t(), (t() -> String.t() | term)) :: [t()] | t()
+  def traverse_errors(errors, fun) when is_list(errors) and is_function(fun, 1) do
+    Enum.map(errors, &traverse_errors(&1, fun))
+  end
+
+  def traverse_errors(%__MODULE__{errors: nil} = err, fun) when is_function(fun, 1) do
+    %{err | message: fun.(err) |> to_string()}
+  end
+
+  def traverse_errors(%__MODULE__{errors: nested} = err, fun)
+      when is_list(nested) and is_function(fun, 1) do
+    %{err | errors: Enum.map(nested, &traverse_errors(&1, fun))}
   end
 
   def update_error_paths(%Peri.Error{path: path, errors: nil} = error, new_path) do

--- a/pages/types.md
+++ b/pages/types.md
@@ -150,6 +150,49 @@ For untagged "any of these types" semantics, use `{:oneof, types}` instead.
 | `{:custom, {mod, fun}}`       | Custom validation MFA       | `{:custom, {MyMod, :validate}}`     |
 | `{:custom, {mod, fun, args}}` | Custom validation with args | `{:custom, {MyMod, :validate, []}}` |
 
+## Custom Error Messages
+
+Override the default error template for any field using the `error:` opt in its
+options list. Accepted forms: a static string, or an MFA `{mod, fun, args}` that
+receives the `%Peri.Error{}` prepended to `args` and returns a string.
+
+| Form                                            | Description                                | Example                                         |
+| ----------------------------------------------- | ------------------------------------------ | ----------------------------------------------- |
+| `{type, [..., error: msg]}`                     | Static replacement message                 | `{:integer, gte: 18, error: "must be adult"}`   |
+| `{:required, type, [error: msg]}`               | Static message on a required field         | `{:required, :string, [error: "needed"]}`       |
+| `{:required, type, [error: {mod, fun, args}]}`  | MFA receives `%Peri.Error{}` and returns string | `{:required, :string, [error: {Msgs, :email, []}]}` |
+
+```elixir
+defmodule MyApp.Schemas do
+  import Peri
+
+  defmodule Msgs do
+    def email_msg(%Peri.Error{content: ctx}), do: "email is invalid (#{inspect(ctx)})"
+  end
+
+  defschema :user, %{
+    age:   {:integer, gte: 18, error: "must be adult"},
+    email: {:required, :string, [error: {Msgs, :email_msg, []}]}
+  }
+end
+```
+
+For i18n, post-process the error list with `Peri.Error.traverse_errors/2`,
+which walks nested errors and replaces each leaf message with the callback's
+return value:
+
+```elixir
+{:error, errors} = MyApp.Schemas.user(%{age: 10})
+
+Peri.Error.traverse_errors(errors, fn err ->
+  Gettext.dgettext(MyAppWeb.Gettext, "errors", err.message, err.content || %{})
+end)
+```
+
+The MFA / static override fires first; `traverse_errors/2` runs over whatever
+message remains (overridden or default). No hard dependency on Gettext —
+the callback is opaque.
+
 ## Examples
 
 ### Simple User Schema

--- a/test/custom_errors_test.exs
+++ b/test/custom_errors_test.exs
@@ -1,0 +1,106 @@
+defmodule Peri.CustomErrorsTest do
+  use ExUnit.Case, async: true
+
+  import Peri
+
+  defmodule Msgs do
+    def email_msg(%Peri.Error{} = err), do: "email is invalid (was: #{inspect(err.content)})"
+    def with_args(%Peri.Error{}, prefix), do: "#{prefix}: bad value"
+  end
+
+  defschema(:user, %{
+    age: {:integer, gte: 18, error: "must be adult"},
+    email: {:required, :string, [error: {Msgs, :email_msg, []}]},
+    nickname: {:string, [min: 3, error: "too short"]}
+  })
+
+  describe "field-level error overrides" do
+    test "static string overrides constraint error" do
+      assert {:error, [%Peri.Error{path: [:age], message: "must be adult"}]} =
+               user(%{age: 10, email: "a@b.io"})
+    end
+
+    test "MFA override receives the Peri.Error and returns string" do
+      assert {:error, errors} = user(%{email: 123})
+      err = Enum.find(errors, &(&1.key == :email))
+      assert err
+      assert is_binary(err.message)
+      assert err.message =~ "email is invalid"
+      assert err.message =~ "(was: "
+    end
+
+    test "MFA override fires when required field is missing" do
+      assert {:error, errors} = user(%{age: 20})
+      err = Enum.find(errors, &(&1.key == :email))
+      assert err.message =~ "email is invalid"
+    end
+
+    test "static string override on nested string constraint" do
+      assert {:error, [%Peri.Error{path: [:nickname], message: "too short"}]} =
+               user(%{age: 20, email: "a@b.io", nickname: "ab"})
+    end
+
+    test "no override means default message" do
+      schema = %{age: {:integer, gte: 18}}
+
+      assert {:error, [%Peri.Error{path: [:age], message: msg}]} =
+               Peri.validate(schema, %{age: 5})
+
+      refute msg == "must be adult"
+    end
+  end
+
+  describe "validate_schema" do
+    test "rejects non-string non-MFA error opt" do
+      schema = %{x: {:integer, [error: 123]}}
+      assert {:error, _} = Peri.validate_schema(schema)
+    end
+
+    test "accepts static string" do
+      schema = %{x: {:integer, [error: "bad"]}}
+      assert {:ok, ^schema} = Peri.validate_schema(schema)
+    end
+
+    test "accepts MFA" do
+      schema = %{x: {:integer, [error: {Mod, :fun, []}]}}
+      assert {:ok, ^schema} = Peri.validate_schema(schema)
+    end
+
+    test "{:required, type, [error: msg]} valid" do
+      schema = %{x: {:required, :string, [error: "needed"]}}
+      assert {:ok, ^schema} = Peri.validate_schema(schema)
+    end
+  end
+
+  describe "Peri.Error.traverse_errors/2" do
+    test "translates flat errors" do
+      {:error, errors} = user(%{age: 10, email: "a@b.io"})
+
+      translated =
+        Peri.Error.traverse_errors(errors, fn err ->
+          "[translated] #{err.message}"
+        end)
+
+      assert Enum.all?(translated, fn err -> String.starts_with?(err.message, "[translated]") end)
+    end
+
+    test "translates nested errors at leaves" do
+      schema = %{outer: %{inner: {:required, :string, [error: "leaf-msg"]}}}
+      {:error, errors} = Peri.validate(schema, %{outer: %{}})
+
+      translated =
+        Peri.Error.traverse_errors(errors, fn err ->
+          "x_" <> err.message
+        end)
+
+      [%Peri.Error{errors: [leaf]}] = translated
+      assert leaf.message == "x_leaf-msg"
+    end
+
+    test "non-string callback result coerces to string" do
+      {:error, errors} = user(%{age: 10, email: "a@b.io"})
+      translated = Peri.Error.traverse_errors(errors, fn _ -> :ok end)
+      assert Enum.all?(translated, fn err -> err.message == "ok" end)
+    end
+  end
+end


### PR DESCRIPTION
**Description**

Adds `error:` opt to any field's options list — static string or MFA `{mod, fun, args}` returning a string — plus `Peri.Error.traverse_errors/2` for Gettext-style translation. No hard Gettext dep. Schema validation rejects non-string / non-MFA `error:` values.

**Related Issues**
Phase 5 of Peri × Malli feature gap plan.

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

**Checklist**

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**

Behavior:
- Static: `{:integer, gte: 18, error: "must be adult"}`
- MFA: `{:required, :string, [error: {Msgs, :email_msg, []}]}` — receives `%Peri.Error{}` prepended to args
- `Peri.Error.traverse_errors/2` mirrors `Ecto.Changeset.traverse_errors/2` — walks nested errors, replaces leaf messages with callback return

367 tests pass. `mix format`, `mix credo --strict`, `mix dialyzer` clean.