### PR TITLE
feat: add Peri.walk/2 schema rewriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Peri is a schema validation library for Elixir, inspired by Clojure's Plumatic S
 - **JSON Schema**: Bidirectional conversion (Draft 7) via `Peri.to_json_schema/2` and `Peri.from_json_schema/1`
 - **Refs**: Recursive and cross-module schemas via `{:ref, atom}` and `{:ref, {Mod, atom}}`
 - **Custom Errors / i18n**: Per-field `error:` overrides (static or MFA) and `Peri.Error.traverse_errors/2` for Gettext-style translation
+- **Schema Transformation**: Depth-first rewrite via `Peri.walk/2` — make-all-optional, strip-fields, rename, etc.
 
 ## Installation
 

--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -148,12 +148,27 @@ defmodule Peri do
   }
   ```
 
+  ## Schema Transformation
+
+  `Peri.walk/2` runs a depth-first rewrite over a schema, useful for
+  derivations like "make every field optional" or "strip private keys from a
+  public DTO". The callback receives `{:field, key, value}` for entries
+  inside a map/keyword schema and the type expression itself everywhere
+  else; return `{:cont, _}` to continue or `:drop` to remove a field. See
+  `Peri.Walker` for full semantics.
+
+      Peri.walk(schema, fn
+        {:required, t} -> {:cont, t}
+        other -> {:cont, other}
+      end)
+
   ## Functions
 
   - `validate/2` - Validates data against a schema.
   - `conforms?/2` - Checks if data conforms to a schema.
   - `validate_schema/1` - Validates the schema definition.
   - `generate/1` - Generates sample data based on schema (when StreamData is available).
+  - `walk/2` - Depth-first rewrite of a schema tree.
 
   ## Example
 
@@ -436,6 +451,28 @@ defmodule Peri do
   """
   @spec from_json_schema(map) :: {:ok, schema} | {:error, term}
   defdelegate from_json_schema(json_schema), to: Peri.JSONSchema.Decoder, as: :decode
+
+  @doc """
+  Depth-first rewrite of a schema tree.
+
+  The callback is invoked on every subtree (pre-order). It must return either
+  `{:cont, new_node}` to replace the node and continue, or `:drop` to remove it
+  (only valid for values inside a map or keyword schema).
+
+  Building block for transforms like "make every field optional" or "strip
+  internal-only fields from a public DTO". See `Peri.Walker` for details.
+
+  ## Examples
+
+      iex> schema = %{name: {:required, :string}, age: {:required, :integer}}
+      iex> Peri.walk(schema, fn
+      ...>   {:required, t} -> {:cont, t}
+      ...>   other -> {:cont, other}
+      ...> end)
+      %{name: :string, age: :integer}
+  """
+  @spec walk(schema, Peri.Walker.walker_fun()) :: schema
+  defdelegate walk(schema, fun), to: Peri.Walker
 
   if Code.ensure_loaded?(StreamData) do
     @doc """
@@ -1514,16 +1551,6 @@ defmodule Peri do
     end
   end
 
-  defp reduce_type_options(options, type, p) do
-    Enum.reduce_while(options, :ok, fn option, :ok ->
-      case validate_type({type, option}, p) do
-        :ok -> {:cont, :ok}
-        {:error, errors} -> {:halt, {:error, errors}}
-        {:error, template, info} -> {:halt, {:error, template, info}}
-      end
-    end)
-  end
-
   defp validate_type({:string, {:regex, %Regex{}}}, _p), do: :ok
   defp validate_type({:string, {:eq, eq}}, _p) when is_binary(eq), do: :ok
   defp validate_type({:string, {:min, min}}, _p) when is_integer(min), do: :ok
@@ -1701,6 +1728,16 @@ defmodule Peri do
   defp validate_type(invalid, _p) do
     invalid = inspect(invalid, pretty: true)
     {:error, "invalid schema definition: %{invalid}", invalid: invalid}
+  end
+
+  defp reduce_type_options(options, type, p) do
+    Enum.reduce_while(options, :ok, fn option, :ok ->
+      case validate_type({type, option}, p) do
+        :ok -> {:cont, :ok}
+        {:error, errors} -> {:halt, {:error, errors}}
+        {:error, template, info} -> {:halt, {:error, template, info}}
+      end
+    end)
   end
 
   if Code.ensure_loaded?(Ecto) do

--- a/lib/peri/walker.ex
+++ b/lib/peri/walker.ex
@@ -1,0 +1,163 @@
+defmodule Peri.Walker do
+  @moduledoc """
+  Depth-first schema rewriter.
+
+  `Peri.walk/2` (delegated here) traverses a schema in pre-order, invoking the
+  supplied callback on every subtree. Callback contract depends on context:
+
+    * **Map / keyword schema entries** — invoked as `{:field, key, value}`.
+      Return one of:
+
+        * `{:cont, {:field, new_key, new_value}}` — replace the entry; the
+          walker recurses into `new_value` as a type expression. `new_key` may
+          differ from the original (rename) and may be any term valid as a key
+          for the surrounding container.
+        * `:drop` — remove the entry from the parent map / keyword list.
+
+    * **Every other subtree** — invoked as the type expression itself
+      (e.g. `:string`, `{:list, …}`, `{:multi, …}`, a nested map). Return:
+
+        * `{:cont, new_node}` — replace and continue walking children of
+          `new_node`.
+        * `:drop` — not allowed in this context; raises.
+
+  Map keys are not visited as standalone nodes; constraint option lists
+  (e.g. `[gte: 18, error: "…"]`), `:enum` members, `:literal` values, `:ref`
+  names, `:multi` tags, callbacks, and transforms are not visited either —
+  only sub-schemas and field entries are.
+
+  Example — make every required field optional:
+
+      Peri.walk(schema, fn
+        {:required, t} -> {:cont, t}
+        {:required, t, _opts} -> {:cont, t}
+        other -> {:cont, other}
+      end)
+
+  Example — strip private fields from a map schema:
+
+      Peri.walk(schema, fn
+        {:field, k, _v} when k in [:internal_id, :secret] -> :drop
+        other -> {:cont, other}
+      end)
+
+  Example — rename `email` to `:login`:
+
+      Peri.walk(schema, fn
+        {:field, :email, v} -> {:cont, {:field, :login, v}}
+        other -> {:cont, other}
+      end)
+  """
+
+  @type field_node :: {:field, term, term}
+  @type sentinel :: {:cont, term} | {:cont, field_node} | :drop
+  @type walker_fun :: (term -> sentinel)
+
+  @spec walk(Peri.schema(), walker_fun) :: Peri.schema()
+  def walk(schema, fun) when is_function(fun, 1) do
+    visit_type(schema, fun)
+  end
+
+  defp visit_type(node, fun) do
+    case fun.(node) do
+      {:cont, new_node} ->
+        walk_type_children(new_node, fun)
+
+      :drop ->
+        raise ArgumentError,
+              "Peri.walk/2 callback returned :drop outside a map field; " <>
+                ":drop is only valid for {:field, k, v} entries"
+
+      other ->
+        raise ArgumentError,
+              "Peri.walk/2 callback must return {:cont, term} | :drop, got: " <>
+                inspect(other)
+    end
+  end
+
+  defp visit_field(key, value, fun) do
+    case fun.({:field, key, value}) do
+      {:cont, {:field, new_key, new_value}} ->
+        {:keep, new_key, visit_type(new_value, fun)}
+
+      :drop ->
+        :drop
+
+      {:cont, other} ->
+        raise ArgumentError,
+              "Peri.walk/2 callback must return {:cont, {:field, k, v}} for a " <>
+                "map field; got {:cont, #{inspect(other)}}"
+
+      other ->
+        raise ArgumentError,
+              "Peri.walk/2 callback must return {:cont, {:field, k, v}} | :drop " <>
+                "for a map field; got: " <> inspect(other)
+    end
+  end
+
+  defp walk_type_children(node, fun) when is_map(node) and not is_struct(node) do
+    Enum.reduce(node, %{}, fn {k, v}, acc ->
+      case visit_field(k, v, fun) do
+        {:keep, new_k, new_v} -> Map.put(acc, new_k, new_v)
+        :drop -> acc
+      end
+    end)
+  end
+
+  defp walk_type_children([{k, _} | _] = node, fun) when is_atom(k) do
+    if Keyword.keyword?(node),
+      do: Enum.flat_map(node, &flat_map_kw_entry(&1, fun)),
+      else: node
+  end
+
+  defp walk_type_children({:required, t}, fun), do: {:required, visit_type(t, fun)}
+
+  defp walk_type_children({:required, t, opts}, fun) when is_list(opts),
+    do: {:required, visit_type(t, fun), opts}
+
+  defp walk_type_children({:list, t}, fun), do: {:list, visit_type(t, fun)}
+
+  defp walk_type_children({:map, t}, fun), do: {:map, visit_type(t, fun)}
+
+  defp walk_type_children({:map, kt, vt}, fun),
+    do: {:map, visit_type(kt, fun), visit_type(vt, fun)}
+
+  defp walk_type_children({:tuple, ts}, fun) when is_list(ts),
+    do: {:tuple, Enum.map(ts, &visit_type(&1, fun))}
+
+  defp walk_type_children({:either, {t1, t2}}, fun),
+    do: {:either, {visit_type(t1, fun), visit_type(t2, fun)}}
+
+  defp walk_type_children({:oneof, ts}, fun) when is_list(ts),
+    do: {:oneof, Enum.map(ts, &visit_type(&1, fun))}
+
+  defp walk_type_children({:meta, t, opts}, fun) when is_list(opts),
+    do: {:meta, visit_type(t, fun), opts}
+
+  defp walk_type_children({:cond, cb, t, el}, fun),
+    do: {:cond, cb, visit_type(t, fun), visit_type(el, fun)}
+
+  defp walk_type_children({:dependent, x, cb, t}, fun) when is_function(cb, 2),
+    do: {:dependent, x, cb, visit_type(t, fun)}
+
+  defp walk_type_children({:multi, field, branches}, fun)
+       when is_atom(field) and is_map(branches) do
+    walked = Map.new(branches, fn {tag, branch} -> {tag, visit_type(branch, fun)} end)
+    {:multi, field, walked}
+  end
+
+  defp walk_type_children({:schema, s}, fun), do: {:schema, visit_type(s, fun)}
+
+  defp walk_type_children({:schema, s, {:additional_keys, t}}, fun) do
+    {:schema, visit_type(s, fun), {:additional_keys, visit_type(t, fun)}}
+  end
+
+  defp walk_type_children(other, _fun), do: other
+
+  defp flat_map_kw_entry({key, value}, fun) do
+    case visit_field(key, value, fun) do
+      {:keep, new_k, new_v} -> [{new_k, new_v}]
+      :drop -> []
+    end
+  end
+end

--- a/pages/types.md
+++ b/pages/types.md
@@ -193,6 +193,56 @@ The MFA / static override fires first; `traverse_errors/2` runs over whatever
 message remains (overridden or default). No hard dependency on Gettext —
 the callback is opaque.
 
+## Schema Transformation (`Peri.walk/2`)
+
+`Peri.walk/2` is a depth-first rewrite over a schema tree — a building block
+for derivations like "make every field optional" or "drop internal-only
+fields from a public DTO". The callback is invoked on every subtree, and its
+contract depends on context:
+
+| Position                            | Callback receives | Valid returns                                   |
+| ----------------------------------- | ----------------- | ----------------------------------------------- |
+| Map / keyword schema entry          | `{:field, k, v}`  | `{:cont, {:field, k', v'}}` or `:drop`          |
+| Any other subtree (type expression) | the node itself   | `{:cont, new_node}` (`:drop` raises here)       |
+
+Map keys, constraint option lists (e.g. `[gte: 18, error: "..."]`), `:enum`
+members, `:literal` values, `:ref` names, `:multi` tags, callbacks, and
+transforms are not visited — only sub-schemas and field entries are.
+
+### Make every field optional
+
+```elixir
+Peri.walk(schema, fn
+  {:required, t} -> {:cont, t}
+  {:required, t, _opts} -> {:cont, t}
+  other -> {:cont, other}
+end)
+```
+
+### Strip private fields from a DTO
+
+```elixir
+Peri.walk(internal_schema, fn
+  {:field, k, _v} when k in [:internal_id, :secret_token] -> :drop
+  other -> {:cont, other}
+end)
+```
+
+### Rename a field
+
+```elixir
+Peri.walk(schema, fn
+  {:field, :email, v} -> {:cont, {:field, :login, v}}
+  other -> {:cont, other}
+end)
+```
+
+### Compose with other tools
+
+The result of `walk/2` is a plain Peri schema, ready to feed to
+`Peri.validate/2`, `Peri.to_json_schema/1`, `Peri.generate/1`, or another
+walker pass.
+
 ## Examples
 
 ### Simple User Schema

--- a/test/walker_test.exs
+++ b/test/walker_test.exs
@@ -1,0 +1,265 @@
+defmodule Peri.WalkerTest do
+  use ExUnit.Case, async: true
+
+  doctest Peri, only: [walk: 2]
+
+  describe "walk/2 — identity" do
+    test "no-op callback preserves the schema" do
+      schema = %{
+        name: {:required, :string},
+        age: {:integer, gte: 0, lte: 120},
+        tags: {:list, :string},
+        addr: %{street: :string, city: {:required, :string}}
+      }
+
+      assert Peri.walk(schema, &{:cont, &1}) == schema
+    end
+
+    test "preserves all directive shapes" do
+      schema = %{
+        a: {:enum, [:x, :y]},
+        b: {:literal, :ok},
+        c: {:either, {:string, :integer}},
+        d: {:oneof, [:string, :integer, :atom]},
+        e: {:tuple, [:float, :float]},
+        f: {:map, :atom, :string},
+        g: {:meta, {:required, :string}, doc: "x"},
+        h: {:multi, :type, %{"a" => %{x: :string}, "b" => %{y: :integer}}},
+        i: {:schema, %{k: :string}, {:additional_keys, :integer}},
+        j: {:string, {:default, "x"}},
+        k: {:integer, {:transform, &(&1 + 1)}},
+        l: {:cond, fn _ -> true end, :string, :integer},
+        m: {:custom, fn _ -> :ok end}
+      }
+
+      assert Peri.walk(schema, &{:cont, &1}) == schema
+    end
+  end
+
+  describe "walk/2 — make-all-optional" do
+    test "strips :required wrappers" do
+      schema = %{
+        name: {:required, :string},
+        age: {:required, :integer},
+        nested: %{x: {:required, :string}, y: :integer}
+      }
+
+      result =
+        Peri.walk(schema, fn
+          {:required, t} -> {:cont, t}
+          other -> {:cont, other}
+        end)
+
+      assert result == %{
+               name: :string,
+               age: :integer,
+               nested: %{x: :string, y: :integer}
+             }
+    end
+
+    test "strips :required inside :list / :map / :either / :oneof / :tuple" do
+      schema = %{
+        items: {:list, {:required, :string}},
+        m: {:map, {:required, :string}},
+        e: {:either, {{:required, :string}, :integer}},
+        o: {:oneof, [{:required, :string}, :integer]},
+        t: {:tuple, [{:required, :float}, :float]}
+      }
+
+      result =
+        Peri.walk(schema, fn
+          {:required, t} -> {:cont, t}
+          other -> {:cont, other}
+        end)
+
+      assert result == %{
+               items: {:list, :string},
+               m: {:map, :string},
+               e: {:either, {:string, :integer}},
+               o: {:oneof, [:string, :integer]},
+               t: {:tuple, [:float, :float]}
+             }
+    end
+  end
+
+  describe "walk/2 — :drop on fields" do
+    test "drops a top-level map field by key" do
+      schema = %{name: :string, secret: :string, age: :integer}
+
+      result =
+        Peri.walk(schema, fn
+          {:field, :secret, _} -> :drop
+          other -> {:cont, other}
+        end)
+
+      assert result == %{name: :string, age: :integer}
+    end
+
+    test "drops a nested map field" do
+      schema = %{outer: %{keep: :integer, drop_me: :string}}
+
+      result =
+        Peri.walk(schema, fn
+          {:field, :drop_me, _} -> :drop
+          other -> {:cont, other}
+        end)
+
+      assert result == %{outer: %{keep: :integer}}
+    end
+
+    test "drops based on field value" do
+      schema = %{name: :string, secret: :string, age: :integer}
+
+      result =
+        Peri.walk(schema, fn
+          {:field, _, :string} -> :drop
+          other -> {:cont, other}
+        end)
+
+      assert result == %{age: :integer}
+    end
+
+    test "raises when :drop returned at root (type-expr position)" do
+      assert_raise ArgumentError, ~r/:drop is only valid/, fn ->
+        Peri.walk(%{a: :string}, fn _ -> :drop end)
+      end
+    end
+
+    test "raises when :drop returned inside a tuple directive" do
+      schema = %{x: {:list, :string}}
+
+      assert_raise ArgumentError, ~r/:drop is only valid/, fn ->
+        Peri.walk(schema, fn
+          :string -> :drop
+          other -> {:cont, other}
+        end)
+      end
+    end
+  end
+
+  describe "walk/2 — rename fields" do
+    test "renames a key via {:cont, {:field, new_k, v}}" do
+      schema = %{email: {:required, :string}, age: :integer}
+
+      result =
+        Peri.walk(schema, fn
+          {:field, :email, v} -> {:cont, {:field, :login, v}}
+          other -> {:cont, other}
+        end)
+
+      assert result == %{login: {:required, :string}, age: :integer}
+    end
+
+    test "rename + recurse: child of new value still walked" do
+      schema = %{outer: {:required, %{inner: {:required, :string}}}}
+
+      result =
+        Peri.walk(schema, fn
+          {:field, :outer, v} -> {:cont, {:field, :renamed, v}}
+          {:required, t} -> {:cont, t}
+          other -> {:cont, other}
+        end)
+
+      assert result == %{renamed: %{inner: :string}}
+    end
+  end
+
+  describe "walk/2 — keyword schemas" do
+    test "walks keyword-list-shaped schema" do
+      schema = [name: {:required, :string}, age: :integer]
+
+      result =
+        Peri.walk(schema, fn
+          {:required, t} -> {:cont, t}
+          other -> {:cont, other}
+        end)
+
+      assert result == [name: :string, age: :integer]
+    end
+
+    test "drops a keyword field" do
+      schema = [name: :string, secret: :string]
+
+      result =
+        Peri.walk(schema, fn
+          {:field, :secret, _} -> :drop
+          other -> {:cont, other}
+        end)
+
+      assert result == [name: :string]
+    end
+  end
+
+  describe "walk/2 — invalid callback returns" do
+    test "raises on unexpected return value at type-expr position" do
+      assert_raise ArgumentError, ~r/must return/, fn ->
+        Peri.walk(%{x: :string}, fn _ -> :nope end)
+      end
+    end
+
+    test "raises on non-field {:cont, _} at field position" do
+      assert_raise ArgumentError, ~r/must return \{:cont, \{:field/, fn ->
+        Peri.walk(%{x: :string}, fn
+          {:field, _, _} -> {:cont, :string}
+          other -> {:cont, other}
+        end)
+      end
+    end
+  end
+
+  describe "walk/2 — :multi branches" do
+    test "transforms inside each branch" do
+      schema = %{
+        shape:
+          {:multi, :type,
+           %{
+             "circle" => %{type: {:required, :string}, r: {:required, :float}},
+             "rect" => %{type: {:required, :string}, w: :float}
+           }}
+      }
+
+      result =
+        Peri.walk(schema, fn
+          {:required, t} -> {:cont, t}
+          other -> {:cont, other}
+        end)
+
+      assert result == %{
+               shape:
+                 {:multi, :type,
+                  %{
+                    "circle" => %{type: :string, r: :float},
+                    "rect" => %{type: :string, w: :float}
+                  }}
+             }
+    end
+  end
+
+  describe "walk/2 — composes with Peri.validate" do
+    test "make-optional + validate accepts data missing previously-required keys" do
+      schema = %{name: {:required, :string}, age: {:required, :integer}}
+
+      relaxed =
+        Peri.walk(schema, fn
+          {:required, t} -> {:cont, t}
+          other -> {:cont, other}
+        end)
+
+      assert {:ok, _} = Peri.validate(relaxed, %{})
+      assert {:error, _} = Peri.validate(schema, %{})
+    end
+
+    test "strip-fields + validate filters out dropped key from accepted data" do
+      schema = %{name: {:required, :string}, secret: :string}
+
+      public =
+        Peri.walk(schema, fn
+          {:field, :secret, _} -> :drop
+          other -> {:cont, other}
+        end)
+
+      data = %{name: "x", secret: "shh"}
+      assert {:ok, %{name: "x"}} = Peri.validate(public, data)
+    end
+  end
+end


### PR DESCRIPTION
**Description**

Adds `Peri.walk/2` — depth-first schema rewrite. Callback is invoked as `{:field, k, v}` for entries inside a map/keyword schema and as the type expression itself everywhere else. Returns `{:cont, _}` to continue (recursing into children) or `:drop` to remove the field.

Building block for derivations like "make every field optional", "strip internal-only keys from a public DTO", or renames.

**Related Issues**
Phase 7a of Peri × Malli feature gap plan.

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

**Checklist**

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**

API:
```elixir
Peri.walk(schema, fn
  {:required, t} -> {:cont, t}                            # type-expr position
  {:field, k, _v} when k in [:secret] -> :drop            # field position
  {:field, :email, v} -> {:cont, {:field, :login, v}}     # rename
  other -> {:cont, other}
end)
```

Constraint opts (`[gte: 18, error: "..."]`), `:enum` members, `:literal` values, `:ref` names, `:multi` tags, callbacks and transforms are not visited — only sub-schemas and field entries.

385 tests pass (19 new). Format, credo --strict, dialyzer clean. Coderabbit review clean.