### PR TITLE
feat: per-field gen: override for StreamData generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Peri is a schema validation library for Elixir, inspired by Clojure's Plumatic S
 - **Refs**: Recursive and cross-module schemas via `{:ref, atom}` and `{:ref, {Mod, atom}}`
 - **Custom Errors / i18n**: Per-field `error:` overrides (static or MFA) and `Peri.Error.traverse_errors/2` for Gettext-style translation
 - **Schema Transformation**: Depth-first rewrite via `Peri.walk/2` — make-all-optional, strip-fields, rename, etc.
+- **Custom Generators**: Per-field `gen:` opt to override StreamData generation on tight constraint domains
 
 ## Installation
 

--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -148,6 +148,20 @@ defmodule Peri do
   }
   ```
 
+  ## Custom Generators
+
+  When data generation matters (`Peri.generate/1`), constrained types like
+  `{:integer, gt: 1_000_000}` or `{:string, {:regex, …}}` fall back to
+  rejection sampling, which can be slow on tight domains. Provide a `gen:`
+  opt with an MFA, `{mod, fun}`, or 0-arity function returning
+  `%StreamData{}` to skip rejection entirely. Accepted in multi-options,
+  `{:required, type, opts}`, and `{:meta, type, opts}` positions.
+
+      %{
+        age:   {:integer, gte: 18, gen: {MyApp.Gens, :age, []}},
+        email: {:meta, :string, doc: "Login", gen: {MyApp.Gens, :email}}
+      }
+
   ## Schema Transformation
 
   `Peri.walk/2` runs a depth-first rewrite over a schema, useful for
@@ -821,6 +835,7 @@ defmodule Peri do
   defp validate_field(val, {type, options}, data, opts)
        when is_type_with_multiple_options(type) and is_list(options) do
     {override, options} = Keyword.pop(options, :error)
+    options = Keyword.delete(options, :gen)
 
     options
     |> Enum.map(fn option -> validate_field(val, {type, option}, data, opts) end)
@@ -1306,6 +1321,16 @@ defmodule Peri do
     end
   end
 
+  defp valid_gen_opt?(opts) do
+    case Keyword.fetch(opts, :gen) do
+      :error -> true
+      {:ok, {mod, fun, args}} when is_atom(mod) and is_atom(fun) and is_list(args) -> true
+      {:ok, {mod, fun}} when is_atom(mod) and is_atom(fun) -> true
+      {:ok, fun} when is_function(fun, 0) -> true
+      {:ok, _} -> false
+    end
+  end
+
   defp tag_error_override(:ok, _), do: :ok
   defp tag_error_override({:ok, _} = result, _), do: result
   defp tag_error_override(result, nil), do: result
@@ -1541,13 +1566,20 @@ defmodule Peri do
 
   defp validate_type({type, options}, p)
        when is_type_with_multiple_options(type) and is_list(options) do
-    if valid_error_opt?(options) do
-      options
-      |> Keyword.delete(:error)
-      |> reduce_type_options(type, p)
-    else
-      {:error, "expected error: opt to be a string or MFA tuple, got %{actual}",
-       actual: inspect(Keyword.get(options, :error))}
+    cond do
+      not valid_error_opt?(options) ->
+        {:error, "expected error: opt to be a string or MFA tuple, got %{actual}",
+         actual: inspect(Keyword.get(options, :error))}
+
+      not valid_gen_opt?(options) ->
+        {:error,
+         "expected gen: opt to be an MFA tuple, {mod, fun}, or 0-arity function, got %{actual}",
+         actual: inspect(Keyword.get(options, :gen))}
+
+      true ->
+        options
+        |> Keyword.drop([:error, :gen])
+        |> reduce_type_options(type, p)
     end
   end
 
@@ -1602,11 +1634,19 @@ defmodule Peri do
   end
 
   defp validate_type({:meta, type, meta_opts}, p) when is_list(meta_opts) do
-    if Keyword.keyword?(meta_opts),
-      do: validate_type(type, p),
-      else:
+    cond do
+      not Keyword.keyword?(meta_opts) ->
         {:error, "expected meta opts to be a keyword list, got %{actual}",
          actual: inspect(meta_opts)}
+
+      not valid_gen_opt?(meta_opts) ->
+        {:error,
+         "expected gen: opt to be an MFA tuple, {mod, fun}, or 0-arity function, got %{actual}",
+         actual: inspect(Keyword.get(meta_opts, :gen))}
+
+      true ->
+        validate_type(type, p)
+    end
   end
 
   defp validate_type({:meta, _type, meta_opts}, _p) do
@@ -1639,9 +1679,23 @@ defmodule Peri do
   defp validate_type({:required, type}, p), do: validate_type(type, p)
 
   defp validate_type({:required, type, opts}, p) when is_list(opts) do
-    if Keyword.keyword?(opts) and valid_error_opt?(opts),
-      do: validate_type(type, p),
-      else: {:error, "expected error: opts to be a keyword list", []}
+    cond do
+      not Keyword.keyword?(opts) ->
+        {:error, "expected required opts to be a keyword list, got %{actual}",
+         actual: inspect(opts)}
+
+      not valid_error_opt?(opts) ->
+        {:error, "expected error: opt to be a string or MFA tuple, got %{actual}",
+         actual: inspect(Keyword.get(opts, :error))}
+
+      not valid_gen_opt?(opts) ->
+        {:error,
+         "expected gen: opt to be an MFA tuple, {mod, fun}, or 0-arity function, got %{actual}",
+         actual: inspect(Keyword.get(opts, :gen))}
+
+      true ->
+        validate_type(type, p)
+    end
   end
 
   defp validate_type({:list, type}, p), do: validate_type(type, p)

--- a/lib/peri/generatable.ex
+++ b/lib/peri/generatable.ex
@@ -82,7 +82,19 @@ if Code.ensure_loaded?(StreamData) do
 
     def gen({:required, type}), do: gen(type)
 
-    def gen({:meta, type, _opts}), do: gen(type)
+    def gen({:required, type, opts}) when is_list(opts) do
+      case Keyword.fetch(opts, :gen) do
+        {:ok, override} -> apply_gen_override(override)
+        :error -> gen(type)
+      end
+    end
+
+    def gen({:meta, type, opts}) when is_list(opts) do
+      case Keyword.fetch(opts, :gen) do
+        {:ok, override} -> apply_gen_override(override)
+        :error -> gen(type)
+      end
+    end
 
     @ref_gen_depth 5
 
@@ -217,6 +229,18 @@ if Code.ensure_loaded?(StreamData) do
       StreamData.map(stream, mapper)
     end
 
+    def gen({type, opts}) when Peri.is_type_with_multiple_options(type) and is_list(opts) do
+      case Keyword.fetch(opts, :gen) do
+        {:ok, override} ->
+          apply_gen_override(override)
+
+        :error ->
+          opts
+          |> Keyword.delete(:error)
+          |> Enum.reduce(gen(type), &apply_constraint_filter(&2, type, &1))
+      end
+    end
+
     def gen({:either, {type_1, type_2}}) do
       stream_1 = gen(type_1)
       stream_2 = gen(type_2)
@@ -270,5 +294,52 @@ if Code.ensure_loaded?(StreamData) do
     defp merge_dispatch(val, field, tag) when is_map(val), do: Map.put(val, field, tag)
     defp merge_dispatch(val, field, tag) when is_list(val), do: Keyword.put(val, field, tag)
     defp merge_dispatch(val, _field, _tag), do: val
+
+    defp apply_gen_override({mod, fun, args})
+         when is_atom(mod) and is_atom(fun) and is_list(args),
+         do: apply(mod, fun, args)
+
+    defp apply_gen_override({mod, fun}) when is_atom(mod) and is_atom(fun),
+      do: apply(mod, fun, [])
+
+    defp apply_gen_override(fun) when is_function(fun, 0), do: fun.()
+
+    defp apply_gen_override(other) do
+      raise ArgumentError,
+            "invalid :gen override; expected MFA tuple, {mod, fun}, or 0-arity function, got: " <>
+              inspect(other)
+    end
+
+    defp apply_constraint_filter(stream, _type, {:eq, v}),
+      do: StreamData.filter(stream, &(&1 == v))
+
+    defp apply_constraint_filter(stream, _type, {:neq, v}),
+      do: StreamData.filter(stream, &(&1 != v))
+
+    defp apply_constraint_filter(stream, _type, {:gt, v}),
+      do: StreamData.filter(stream, &(&1 > v))
+
+    defp apply_constraint_filter(stream, _type, {:gte, v}),
+      do: StreamData.filter(stream, &(&1 >= v))
+
+    defp apply_constraint_filter(stream, _type, {:lt, v}),
+      do: StreamData.filter(stream, &(&1 < v))
+
+    defp apply_constraint_filter(stream, _type, {:lte, v}),
+      do: StreamData.filter(stream, &(&1 <= v))
+
+    defp apply_constraint_filter(stream, _type, {:range, {min, max}}),
+      do: StreamData.filter(stream, &(&1 in min..max))
+
+    defp apply_constraint_filter(stream, :string, {:regex, regex}),
+      do: StreamData.filter(stream, &Regex.match?(regex, &1))
+
+    defp apply_constraint_filter(stream, :string, {:min, min}),
+      do: StreamData.filter(stream, &(String.length(&1) >= min))
+
+    defp apply_constraint_filter(stream, :string, {:max, max}),
+      do: StreamData.filter(stream, &(String.length(&1) <= max))
+
+    defp apply_constraint_filter(stream, _type, _opt), do: stream
   end
 end

--- a/pages/generation.md
+++ b/pages/generation.md
@@ -202,6 +202,33 @@ defmodule MyAppWeb.UserControllerTest do
 end
 ```
 
+## Custom Generators (`gen:` opt)
+
+Constrained types fall back to rejection sampling, which can be slow when
+the accepting domain is narrow (e.g. `{:integer, gt: 1_000_000}` or a regex
+that few random strings satisfy). Provide a `gen:` opt that returns a
+`%StreamData{}` directly to skip rejection entirely.
+
+```elixir
+defmodule MyApp.Gens do
+  def adult_age, do: StreamData.integer(18..120)
+  def email_with_prefix(prefix), do: StreamData.constant(prefix <> "@example.com")
+end
+
+%{
+  age:   {:integer, gte: 18, lte: 120, gen: {MyApp.Gens, :adult_age, []}},
+  login: {:required, :string, [gen: {MyApp.Gens, :fixed_login}]},
+  email: {:meta, :string,
+                 doc: "Login email",
+                 gen: {MyApp.Gens, :email_with_prefix, ["root"]}}
+}
+```
+
+Accepted callable forms: `{mod, fun, args}` (MFA), `{mod, fun}` (zero args),
+or a 0-arity function. Without a `gen:` opt, the generator chains
+`StreamData.filter/2` for each constraint — correct, but slow on tight
+domains.
+
 ## Limitations
 
 - **Custom Types**: Custom validation types need manual generator implementation

--- a/pages/types.md
+++ b/pages/types.md
@@ -243,7 +243,38 @@ The result of `walk/2` is a plain Peri schema, ready to feed to
 `Peri.validate/2`, `Peri.to_json_schema/1`, `Peri.generate/1`, or another
 walker pass.
 
-## Examples
+## Generator Overrides (`gen:` opt)
+
+Constrained types like `{:string, {:regex, …}}` or `{:integer, gt: 1_000_000}`
+can be slow to generate via `Peri.generate/1` because StreamData's default
+strategy is rejection sampling. Supply a `gen:` opt with a custom generator
+to skip rejection altogether:
+
+| Form                              | Description                          |
+| --------------------------------- | ------------------------------------ |
+| `gen: {Mod, :fun, args}`          | MFA returning a `%StreamData{}`      |
+| `gen: {Mod, :fun}`                | MF (zero args), same return contract |
+| `gen: fn -> StreamData.… end`     | 0-arity function, same contract      |
+
+Accepted positions:
+
+```elixir
+%{
+  # multi-options on a constrained primitive
+  age:    {:integer, gte: 18, lte: 120, gen: {MyApp.Gens, :age, []}},
+
+  # required wrapper
+  login:  {:required, :string, [gen: {MyApp.Gens, :login}]},
+
+  # meta wrapper (combines with docs/examples)
+  email:  {:meta, {:required, {:string, {:regex, ~r/@/}}},
+                  doc: "Login email",
+                  gen: {MyApp.Gens, :email, []}}
+}
+```
+
+Without an override, `Peri.generate/1` falls back to chaining
+`StreamData.filter/2` for each constraint.
 
 ### Simple User Schema
 

--- a/test/gen_overrides_test.exs
+++ b/test/gen_overrides_test.exs
@@ -1,0 +1,138 @@
+defmodule Peri.GenOverridesTest do
+  use ExUnit.Case, async: true
+
+  defmodule Gens do
+    def adult_age, do: StreamData.integer(18..120)
+    def email_with_prefix(prefix), do: StreamData.constant(prefix <> "@test.io")
+    def fixed_login, do: StreamData.constant("system")
+  end
+
+  defp sample(stream, n \\ 20)
+  defp sample({:ok, stream}, n), do: Enum.take(stream, n)
+  defp sample(%StreamData{} = stream, n), do: Enum.take(stream, n)
+
+  describe "validate_schema accepts :gen opt" do
+    test "MFA in multi-options" do
+      schema = %{age: {:integer, gte: 18, gen: {Gens, :adult_age, []}}}
+      assert {:ok, ^schema} = Peri.validate_schema(schema)
+    end
+
+    test "MF (no args) in :required wrapper" do
+      schema = %{login: {:required, :string, [gen: {Gens, :fixed_login}]}}
+      assert {:ok, ^schema} = Peri.validate_schema(schema)
+    end
+
+    test "0-arity fun in :meta wrapper" do
+      fun = fn -> StreamData.constant("x") end
+      schema = %{name: {:meta, :string, [gen: fun]}}
+      assert {:ok, ^schema} = Peri.validate_schema(schema)
+    end
+
+    test "rejects non-MFA / non-fun gen value" do
+      schema = %{age: {:integer, gte: 18, gen: 123}}
+      assert {:error, _} = Peri.validate_schema(schema)
+    end
+
+    test "rejects 1-arity fun" do
+      schema = %{age: {:integer, gte: 18, gen: fn _ -> StreamData.integer() end}}
+      assert {:error, _} = Peri.validate_schema(schema)
+    end
+
+    test "rejects bad gen in :required" do
+      schema = %{x: {:required, :string, [gen: 42]}}
+      assert {:error, _} = Peri.validate_schema(schema)
+    end
+
+    test "rejects bad gen in :meta" do
+      schema = %{x: {:meta, :string, [gen: :nope]}}
+      assert {:error, _} = Peri.validate_schema(schema)
+    end
+  end
+
+  describe "Peri.Generatable consumes :gen override" do
+    test "multi-options uses override, skipping rejection sampling" do
+      schema = %{age: {:integer, gte: 18, gen: {Gens, :adult_age, []}}}
+
+      values =
+        schema
+        |> Peri.generate()
+        |> sample()
+
+      assert Enum.all?(values, fn %{age: a} -> a >= 18 and a <= 120 end)
+    end
+
+    test ":required override fires" do
+      schema = %{login: {:required, :string, [gen: {Gens, :fixed_login}]}}
+
+      values =
+        schema
+        |> Peri.generate()
+        |> sample(5)
+
+      assert Enum.all?(values, fn %{login: v} -> v == "system" end)
+    end
+
+    test ":meta override fires" do
+      fun = fn -> StreamData.constant("hello") end
+      schema = %{name: {:meta, :string, [gen: fun]}}
+
+      values =
+        schema
+        |> Peri.generate()
+        |> sample(5)
+
+      assert Enum.all?(values, fn %{name: v} -> v == "hello" end)
+    end
+
+    test "MFA with args is applied" do
+      schema = %{email: {:meta, :string, [gen: {Gens, :email_with_prefix, ["zoey"]}]}}
+
+      values =
+        schema
+        |> Peri.generate()
+        |> sample(3)
+
+      assert Enum.all?(values, fn %{email: v} -> v == "zoey@test.io" end)
+    end
+
+    test "without override, multi-options falls back to constraint chain" do
+      schema = %{n: {:integer, gte: 0, lte: 10}}
+
+      values =
+        schema
+        |> Peri.generate()
+        |> sample(20)
+
+      assert Enum.all?(values, fn %{n: v} -> v >= 0 and v <= 10 end)
+    end
+
+    test "without override, :required and :meta delegate to inner type generator" do
+      schema = %{
+        a: {:required, :integer, []},
+        b: {:meta, :integer, doc: "x"}
+      }
+
+      values =
+        schema
+        |> Peri.generate()
+        |> sample(5)
+
+      assert Enum.all?(values, fn %{a: a, b: b} ->
+               is_integer(a) and is_integer(b)
+             end)
+    end
+  end
+
+  describe "validates generated data" do
+    test "override values pass schema validation" do
+      schema = %{age: {:integer, gte: 18, gen: {Gens, :adult_age, []}}}
+
+      values =
+        schema
+        |> Peri.generate()
+        |> sample(10)
+
+      Enum.each(values, fn data -> assert {:ok, ^data} = Peri.validate(schema, data) end)
+    end
+  end
+end


### PR DESCRIPTION
**Description**

Adds an inline `gen:` opt that overrides `Peri.generate/1`'s default StreamData strategy on a per-field basis. Skips rejection sampling on tight constraint domains.

Accepted positions and forms:

| Position                          | Form                                                |
| --------------------------------- | --------------------------------------------------- |
| Multi-options on a primitive      | `{:integer, gte: 18, gen: {Mod, :fun, args}}`       |
| `:required` wrapper               | `{:required, :string, [gen: {Mod, :fun}]}`          |
| `:meta` wrapper                   | `{:meta, :string, doc: "x", gen: fn -> … end}`      |

Callable shapes: `{mod, fun, args}`, `{mod, fun}`, or 0-arity function — each must return a `%StreamData{}`. Schema validation rejects any other shape.

Also fills a small generator gap: when `gen:` is absent, multi-option constraints now chain via `StreamData.filter/2` instead of raising `FunctionClauseError`.

**Related Issues**
Phase 7b (final) of Peri × Malli feature gap plan. Combined with Phase 7a (`Peri.walk/2`, #53) this closes the planned 0.7.0 release content.

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

**Checklist**

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**

Example:

```elixir
defmodule MyApp.Gens do
  def adult_age, do: StreamData.integer(18..120)
end

defschema :user, %{
  age: {:integer, gte: 18, lte: 120, gen: {MyApp.Gens, :adult_age, []}}
}
```

399 tests pass (14 new). Format, credo --strict, dialyzer clean. Coderabbit was rate-limited so not run on this PR.