### PR TITLE
feat: list constraints (:min/:max/:unique) and :multiple_of

### DIFF
--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -945,6 +945,15 @@ defmodule Peri do
     end
   end
 
+  defp validate_field(val, {type, {:multiple_of, n}}, _data, _opts)
+       when is_numeric_type(type) and is_numeric(val) and is_numeric(n) do
+    if multiple_of?(val, n) do
+      :ok
+    else
+      {:error, "should be a multiple of %{value}", [value: n]}
+    end
+  end
+
   defp validate_field(val, {type, {:default, {mod, fun}}}, data, opts)
        when is_atom(mod) and is_atom(fun) do
     validate_field(val, {type, {:default, apply(mod, fun, [])}}, data, opts)
@@ -1178,6 +1187,15 @@ defmodule Peri do
     end)
   end
 
+  defp validate_field(data, {:list, type, list_opts}, source, opts)
+       when is_list(data) and is_list(list_opts) do
+    constraint_opts = Keyword.drop(list_opts, [:error, :gen])
+
+    with :ok <- check_list_constraints(data, constraint_opts) do
+      validate_field(data, {:list, type}, source, opts)
+    end
+  end
+
   defp validate_field(data, {:map, type}, source, opts) when is_map(data) do
     Enum.reduce_while(data, {:ok, %{}}, fn {key, val}, {:ok, map_acc} ->
       case validate_field(val, type, source, opts) do
@@ -1329,6 +1347,61 @@ defmodule Peri do
       {:ok, fun} when is_function(fun, 0) -> true
       {:ok, _} -> false
     end
+  end
+
+  defp valid_list_opts?(opts) do
+    Enum.all?(opts, fn
+      {:min, n} when is_integer(n) and n >= 0 -> true
+      {:max, n} when is_integer(n) and n >= 0 -> true
+      {:unique, b} when is_boolean(b) -> true
+      {:error, _} -> true
+      {:gen, _} -> true
+      _ -> false
+    end)
+  end
+
+  defp check_list_constraints(data, list_opts) do
+    Enum.reduce_while(list_opts, :ok, fn opt, :ok ->
+      case check_list_constraint(data, opt) do
+        :ok -> {:cont, :ok}
+        err -> {:halt, err}
+      end
+    end)
+  end
+
+  defp check_list_constraint(data, {:min, min}) when is_integer(min) do
+    if length(data) >= min do
+      :ok
+    else
+      {:error, "should have at least %{min} items", [min: min]}
+    end
+  end
+
+  defp check_list_constraint(data, {:max, max}) when is_integer(max) do
+    if length(data) <= max do
+      :ok
+    else
+      {:error, "should have at most %{max} items", [max: max]}
+    end
+  end
+
+  defp check_list_constraint(data, {:unique, true}) do
+    if length(Enum.uniq(data)) == length(data) do
+      :ok
+    else
+      {:error, "should have unique items", []}
+    end
+  end
+
+  defp check_list_constraint(_data, {:unique, false}), do: :ok
+  defp check_list_constraint(_data, _opt), do: :ok
+
+  defp multiple_of?(_val, 0), do: false
+  defp multiple_of?(val, n) when is_integer(val) and is_integer(n), do: rem(val, n) == 0
+
+  defp multiple_of?(val, n) when is_number(val) and is_number(n) do
+    quotient = val / n
+    abs(quotient - Float.round(quotient)) < 1.0e-9
   end
 
   defp tag_error_override(:ok, _), do: :ok
@@ -1616,6 +1689,15 @@ defmodule Peri do
        when is_numeric_type(type) and is_numeric(min) and is_numeric(max),
        do: :ok
 
+  defp validate_type({type, {:multiple_of, n}}, _parer)
+       when is_numeric_type(type) and is_numeric(n) and n != 0,
+       do: :ok
+
+  defp validate_type({type, {:multiple_of, n}}, _parer) when is_numeric_type(type) do
+    {:error, "expected :multiple_of value to be a non-zero number, got %{actual}",
+     actual: inspect(n)}
+  end
+
   defp validate_type({type, {:transform, mapper}}, p) when is_function(mapper, 1),
     do: validate_type(type, p)
 
@@ -1699,6 +1781,22 @@ defmodule Peri do
   end
 
   defp validate_type({:list, type}, p), do: validate_type(type, p)
+
+  defp validate_type({:list, type, list_opts}, p) when is_list(list_opts) do
+    cond do
+      not Keyword.keyword?(list_opts) ->
+        {:error, "expected list opts to be a keyword list, got %{actual}",
+         actual: inspect(list_opts)}
+
+      not valid_list_opts?(list_opts) ->
+        {:error, "invalid list constraint, allowed: :min, :max, :unique; got %{actual}",
+         actual: inspect(list_opts)}
+
+      true ->
+        validate_type(type, p)
+    end
+  end
+
   defp validate_type({:map, type}, p), do: validate_type(type, p)
 
   defp validate_type({:map, key_type, value_type}, p) do

--- a/lib/peri/generatable.ex
+++ b/lib/peri/generatable.ex
@@ -142,6 +142,23 @@ if Code.ensure_loaded?(StreamData) do
       |> StreamData.list_of()
     end
 
+    def gen({:list, type, list_opts}) when is_list(list_opts) do
+      sd_opts =
+        Enum.flat_map(list_opts, fn
+          {:min, n} -> [min_length: n]
+          {:max, n} -> [max_length: n]
+          _ -> []
+        end)
+
+      stream = StreamData.list_of(gen(type), sd_opts)
+
+      if Keyword.get(list_opts, :unique) == true do
+        StreamData.map(stream, &Enum.uniq/1)
+      else
+        stream
+      end
+    end
+
     def gen({:map, type}) do
       key_generator =
         StreamData.one_of([
@@ -200,6 +217,10 @@ if Code.ensure_loaded?(StreamData) do
     def gen({type, {:range, {min, max}}}) when Peri.is_numeric_type(type) do
       stream = gen(type)
       StreamData.filter(stream, &(&1 in min..max))
+    end
+
+    def gen({type, {:multiple_of, n}}) when Peri.is_numeric_type(type) do
+      gen(type) |> apply_multiple_of(n)
     end
 
     def gen({:string, {:regex, regex}}) do
@@ -328,6 +349,11 @@ if Code.ensure_loaded?(StreamData) do
     defp apply_constraint_filter(stream, _type, {:lte, v}),
       do: StreamData.filter(stream, &(&1 <= v))
 
+    defp apply_constraint_filter(stream, type, {:multiple_of, n})
+         when type in [:integer, :float] do
+      apply_multiple_of(stream, n)
+    end
+
     defp apply_constraint_filter(stream, _type, {:range, {min, max}}),
       do: StreamData.filter(stream, &(&1 in min..max))
 
@@ -341,5 +367,19 @@ if Code.ensure_loaded?(StreamData) do
       do: StreamData.filter(stream, &(String.length(&1) <= max))
 
     defp apply_constraint_filter(stream, _type, _opt), do: stream
+
+    defp apply_multiple_of(stream, 0),
+      do: StreamData.filter(stream, fn _ -> false end)
+
+    defp apply_multiple_of(stream, n) when is_integer(n) do
+      StreamData.map(stream, fn
+        val when is_integer(val) -> val - rem(val, n)
+        val when is_float(val) -> Float.round(val / n) * n
+      end)
+    end
+
+    defp apply_multiple_of(stream, n) when is_float(n) do
+      StreamData.map(stream, fn val -> Float.round(val / n) * n end)
+    end
   end
 end

--- a/lib/peri/json_schema/decoder.ex
+++ b/lib/peri/json_schema/decoder.ex
@@ -107,11 +107,38 @@ defmodule Peri.JSONSchema.Decoder do
     ArgumentError -> key
   end
 
-  defp convert_array(%{"items" => items}) do
-    {:list, convert_schema(items)}
+  defp convert_array(%{"items" => items} = schema) do
+    base = {:list, convert_schema(items)}
+    apply_list_constraints(base, schema)
   end
 
-  defp convert_array(_), do: {:list, :any}
+  defp convert_array(schema) do
+    apply_list_constraints({:list, :any}, schema)
+  end
+
+  defp apply_list_constraints({:list, item}, schema) do
+    list_opts =
+      []
+      |> maybe_put(schema, "minItems", :min)
+      |> maybe_put(schema, "maxItems", :max)
+      |> maybe_put_unique(schema)
+
+    if list_opts == [], do: {:list, item}, else: {:list, item, list_opts}
+  end
+
+  defp maybe_put(opts, schema, json_key, peri_key) do
+    case Map.get(schema, json_key) do
+      nil -> opts
+      value -> opts ++ [{peri_key, value}]
+    end
+  end
+
+  defp maybe_put_unique(opts, schema) do
+    case Map.get(schema, "uniqueItems") do
+      true -> opts ++ [unique: true]
+      _ -> opts
+    end
+  end
 
   defp convert_string(schema) do
     :string
@@ -141,6 +168,7 @@ defmodule Peri.JSONSchema.Decoder do
     |> apply_constraint(schema, "maximum", :lte)
     |> apply_constraint(schema, "exclusiveMinimum", :gt)
     |> apply_constraint(schema, "exclusiveMaximum", :lt)
+    |> apply_constraint(schema, "multipleOf", :multiple_of)
   end
 
   defp convert_integer(schema) do
@@ -149,6 +177,7 @@ defmodule Peri.JSONSchema.Decoder do
     |> apply_constraint(schema, "maximum", :lte)
     |> apply_constraint(schema, "exclusiveMinimum", :gt)
     |> apply_constraint(schema, "exclusiveMaximum", :lt)
+    |> apply_constraint(schema, "multipleOf", :multiple_of)
   end
 
   defp apply_constraint({base, constraints}, schema, json_key, handler)

--- a/lib/peri/json_schema/encoder.ex
+++ b/lib/peri/json_schema/encoder.ex
@@ -138,6 +138,9 @@ defmodule Peri.JSONSchema.Encoder do
     |> Map.put("maximum", max)
   end
 
+  defp convert({type, {:multiple_of, n}}, _) when type in [:integer, :float],
+    do: Map.put(numeric_base(type), "multipleOf", n)
+
   defp convert({type, opts}, encoder_opts) when type in [:integer, :float] and is_list(opts) do
     Enum.reduce(opts, numeric_base(type), fn opt, acc ->
       Map.merge(acc, convert({type, opt}, encoder_opts))
@@ -146,6 +149,17 @@ defmodule Peri.JSONSchema.Encoder do
 
   defp convert({:list, item_type}, opts) do
     %{"type" => "array", "items" => convert(item_type, opts)}
+  end
+
+  defp convert({:list, item_type, list_opts}, opts) when is_list(list_opts) do
+    base = %{"type" => "array", "items" => convert(item_type, opts)}
+
+    Enum.reduce(list_opts, base, fn
+      {:min, n}, acc -> Map.put(acc, "minItems", n)
+      {:max, n}, acc -> Map.put(acc, "maxItems", n)
+      {:unique, true}, acc -> Map.put(acc, "uniqueItems", true)
+      _, acc -> acc
+    end)
   end
 
   defp convert({:map, value_type}, opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,9 @@ defmodule Peri.MixProject do
         "pages/types.md",
         "pages/validation.md",
         "pages/ecto.md",
-        "pages/generation.md"
+        "pages/generation.md",
+        "pages/json_schema.md",
+        "pages/refs.md"
       ],
       groups_for_extras: [
         Guides: ~r/pages\/.*/

--- a/pages/types.md
+++ b/pages/types.md
@@ -30,6 +30,7 @@ Peri provides a comprehensive set of built-in types for schema validation.
 | Type                                              | Description                                                               | Example                                                     |
 | ------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | `{:list, type}`                                   | List of elements of specified type                                        | `{:list, :string}`                                          |
+| `{:list, type, opts}`                             | List with constraints (`:min`, `:max`, `:unique`)                         | `{:list, :string, [min: 1, max: 10, unique: true]}`         |
 | `{:map, type}`                                    | Map with values of specified type                                         | `{:map, :integer}`                                          |
 | `{:map, key_type, value_type}`                    | Map with typed keys and values                                            | `{:map, :atom, :string}`                                    |
 | `{:tuple, types}`                                 | Tuple with elements of specified types                                    | `{:tuple, [:float, :float]}`                                |
@@ -56,6 +57,7 @@ Peri provides a comprehensive set of built-in types for schema validation.
 | `{:integer, {:lt, value}}`         | Integer less than value          | `{:integer, {:lt, 100}}`         |
 | `{:integer, {:lte, value}}`        | Integer less than or equal       | `{:integer, {:lte, 99}}`         |
 | `{:integer, {:range, {min, max}}}` | Integer within range (inclusive) | `{:integer, {:range, {18, 65}}}` |
+| `{:integer, {:multiple_of, n}}`    | Integer divisible by `n`         | `{:integer, {:multiple_of, 5}}`  |
 | `{:integer, [...options]}`         | Integer with multiple options    | `{:integer, [gt: 12, lte: 96]}`  |
 
 ## Float Constraints
@@ -69,6 +71,7 @@ Peri provides a comprehensive set of built-in types for schema validation.
 | `{:float, {:lt, value}}`         | Float less than value          | `{:float, {:lt, 10.0}}`             |
 | `{:float, {:lte, value}}`        | Float less than or equal       | `{:float, {:lte, 99.999}}`          |
 | `{:float, {:range, {min, max}}}` | Float within range (inclusive) | `{:float, {:range, {8.3, 15.3}}}`   |
+| `{:float, {:multiple_of, n}}`    | Float divisible by `n`         | `{:float, {:multiple_of, 0.25}}`    |
 | `{:float, [...options]}`         | Float with multiple options    | `{:float, [gt: 1.52, lte: 29.123]}` |
 
 ## Choice Types

--- a/test/list_constraints_test.exs
+++ b/test/list_constraints_test.exs
@@ -1,0 +1,164 @@
+defmodule Peri.ListConstraintsTest do
+  use ExUnit.Case, async: true
+
+  describe "validate_schema/1 — list constraint shape" do
+    test "accepts :min, :max, :unique" do
+      assert {:ok, _} = Peri.validate_schema({:list, :integer, [min: 1, max: 5, unique: true]})
+    end
+
+    test "rejects unknown constraint" do
+      assert {:error, _} = Peri.validate_schema({:list, :integer, [foo: 1]})
+    end
+
+    test "rejects non-keyword opts" do
+      assert {:error, _} = Peri.validate_schema({:list, :integer, [:bogus]})
+    end
+  end
+
+  describe "validate/2 — :list with constraints" do
+    test ":min enforced" do
+      schema = %{tags: {:list, :string, [min: 2]}}
+      assert {:error, [err]} = Peri.validate(schema, %{tags: ["a"]})
+      assert err.message =~ "at least 2"
+      assert {:ok, _} = Peri.validate(schema, %{tags: ["a", "b"]})
+    end
+
+    test ":max enforced" do
+      schema = %{tags: {:list, :string, [max: 2]}}
+      assert {:error, [err]} = Peri.validate(schema, %{tags: ["a", "b", "c"]})
+      assert err.message =~ "at most 2"
+    end
+
+    test ":unique enforced" do
+      schema = %{tags: {:list, :string, [unique: true]}}
+      assert {:error, [err]} = Peri.validate(schema, %{tags: ["a", "a"]})
+      assert err.message =~ "unique"
+      assert {:ok, _} = Peri.validate(schema, %{tags: ["a", "b"]})
+    end
+
+    test "still validates element types" do
+      schema = %{nums: {:list, :integer, [min: 1]}}
+      assert {:error, _} = Peri.validate(schema, %{nums: ["x"]})
+    end
+  end
+
+  describe "validate/2 — :multiple_of" do
+    test "integer multiple_of" do
+      schema = %{n: {:integer, {:multiple_of, 3}}}
+      assert {:ok, _} = Peri.validate(schema, %{n: 9})
+      assert {:error, [err]} = Peri.validate(schema, %{n: 10})
+      assert err.message =~ "multiple of"
+    end
+
+    test "float multiple_of" do
+      schema = %{n: {:float, {:multiple_of, 0.5}}}
+      assert {:ok, _} = Peri.validate(schema, %{n: 1.5})
+      assert {:error, _} = Peri.validate(schema, %{n: 1.3})
+    end
+
+    test "schema rejects zero divisor" do
+      assert {:error, _} = Peri.validate_schema({:integer, {:multiple_of, 0}})
+    end
+
+    test "works inside opts list" do
+      schema = %{n: {:integer, [gte: 0, multiple_of: 5]}}
+      assert {:ok, _} = Peri.validate(schema, %{n: 25})
+      assert {:error, _} = Peri.validate(schema, %{n: 24})
+    end
+  end
+
+  describe "to_json_schema/2 — encoder" do
+    test "list constraints emit minItems/maxItems/uniqueItems" do
+      assert Peri.to_json_schema({:list, :integer, [min: 1, max: 3, unique: true]}) == %{
+               "type" => "array",
+               "items" => %{"type" => "integer"},
+               "minItems" => 1,
+               "maxItems" => 3,
+               "uniqueItems" => true
+             }
+    end
+
+    test "multipleOf emitted for numerics" do
+      assert Peri.to_json_schema({:integer, {:multiple_of, 5}}) == %{
+               "type" => "integer",
+               "multipleOf" => 5
+             }
+
+      assert Peri.to_json_schema({:float, {:multiple_of, 0.25}}) == %{
+               "type" => "number",
+               "multipleOf" => 0.25
+             }
+    end
+
+    test "merges with other numeric opts" do
+      json = Peri.to_json_schema({:integer, [gte: 0, multiple_of: 2]})
+      assert json["type"] == "integer"
+      assert json["minimum"] == 0
+      assert json["multipleOf"] == 2
+    end
+  end
+
+  describe "from_json_schema/1 — decoder" do
+    test "decodes minItems/maxItems/uniqueItems" do
+      json = %{
+        "type" => "array",
+        "items" => %{"type" => "string"},
+        "minItems" => 1,
+        "maxItems" => 4,
+        "uniqueItems" => true
+      }
+
+      assert {:ok, {:list, :string, opts}} = Peri.from_json_schema(json)
+      assert opts[:min] == 1
+      assert opts[:max] == 4
+      assert opts[:unique] == true
+    end
+
+    test "decodes multipleOf for integer" do
+      json = %{"type" => "integer", "multipleOf" => 5}
+      assert {:ok, {:integer, {:multiple_of, 5}}} = Peri.from_json_schema(json)
+    end
+
+    test "plain array still decodes to {:list, t}" do
+      json = %{"type" => "array", "items" => %{"type" => "integer"}}
+      assert {:ok, {:list, :integer}} = Peri.from_json_schema(json)
+    end
+  end
+
+  describe "roundtrip" do
+    test "list constraints roundtrip" do
+      peri = {:list, :integer, [min: 1, max: 3, unique: true]}
+      json = Peri.to_json_schema(peri)
+      assert {:ok, decoded} = Peri.from_json_schema(json)
+      assert decoded == peri
+    end
+
+    test "multiple_of roundtrip" do
+      peri = {:integer, {:multiple_of, 5}}
+      json = Peri.to_json_schema(peri)
+      assert {:ok, ^peri} = Peri.from_json_schema(json)
+    end
+  end
+
+  if Code.ensure_loaded?(StreamData) do
+    describe "Generatable" do
+      test "list with min/max generates within bounds" do
+        schema = {:list, :integer, [min: 2, max: 4]}
+
+        for list <- Enum.take(Peri.Generatable.gen(schema), 20) do
+          assert length(list) >= 2
+          assert length(list) <= 4
+          assert Enum.all?(list, &is_integer/1)
+        end
+      end
+
+      test "multiple_of generates valid integers" do
+        schema = {:integer, {:multiple_of, 3}}
+
+        for n <- Enum.take(Peri.Generatable.gen(schema), 20) do
+          assert rem(n, 3) == 0
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Description**

Adds `{:list, type, opts}` with `:min`, `:max`, `:unique` constraints, plus `{numeric, {:multiple_of, n}}` for integer/float divisibility checks. Closes the JSON Schema fidelity gap left by the Anubis converter notes (`minItems`/`maxItems`/`uniqueItems`/`multipleOf`).

Wired through validator, schema-shape check, JSON Schema encoder/decoder (roundtrip), and StreamData generator.

Skipped `:not` — adds negation primitive Peri lacks elsewhere, semantics fuzzy on partial map matches, and generator side painful (high rejection rate). Defer until concrete use case.

**Related Issues**
N/A

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

**Checklist**

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**

- 21 new tests in `test/list_constraints_test.exs`, full suite 420/420 green
- `mix credo --strict` clean, `mix format` applied
- Doc rows added to `pages/types.md` (per project convention: extend types page, not new feature page)
- Generator strategy for `:multiple_of` uses `StreamData.map` (snap to nearest multiple) instead of filter — avoids high rejection rate
- `:unique` generator applies `Enum.uniq` post-gen (best-effort; may produce shorter lists than `:min` requests in edge cases)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * List validation now supports constraints for minimum/maximum item counts and element uniqueness.
  * Numeric validation now supports the `multiple_of` constraint.
  * JSON Schema encoder/decoder now handle list constraints and numeric `multiple_of`.
  * Data generation respects all new constraints.

* **Documentation**
  * Updated type documentation with constraint examples for lists and numeric types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->