### PR TITLE
feat: compact schema summaries in error messages

### DIFF
--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -1,4 +1,6 @@
 defmodule Peri do
+  import Peri.Error, only: [summarize: 1]
+
   @moduledoc """
   Peri is a schema validation library for Elixir, inspired by Clojure's Plumatic Schema.
   It provides a flexible and powerful way to define and validate data structures using schemas.
@@ -810,14 +812,14 @@ defmodule Peri do
   end
 
   defp validate_field(nil, {:required, type}, _data, _opts) do
-    {:error, "is required, expected type of %{expected}", expected: type}
+    {:error, "is required, expected type of %{expected}", expected: summarize(type)}
   end
 
   defp validate_field(_val, {:required, {type, {:default, default}}}, _data, _opts) do
     template =
       "cannot set default value of #{inspect(default)} for required field of type %{type}"
 
-    {:ok, template, [type: type]}
+    {:ok, template, [type: summarize(type)]}
   end
 
   # Empty maps and lists are valid for required fields - only nil is invalid
@@ -1102,7 +1104,12 @@ defmodule Peri do
   defp validate_field(val, {:either, {type_1, type_2}}, data, opts) do
     with {:error, _} <- normalize_validation_result(validate_field(val, type_1, data, opts)),
          {:error, _} <- normalize_validation_result(validate_field(val, type_2, data, opts)) do
-      info = [first_type: type_1, second_type: type_2, actual: inspect(val)]
+      info = [
+        first_type: summarize(type_1),
+        second_type: summarize(type_2),
+        actual: inspect(val)
+      ]
+
       template = "expected either %{first_type} or %{second_type}, got: %{actual}"
       {:error, template, info}
     end
@@ -1126,7 +1133,7 @@ defmodule Peri do
         {:ok, val}
 
       :error ->
-        expected = Enum.map_join(types, " or ", &inspect/1)
+        expected = Enum.map_join(types, " or ", &summarize/1)
         info = [oneof: expected, actual: inspect(val)]
         template = "expected one of %{oneof}, got: %{actual}"
 
@@ -1218,6 +1225,11 @@ defmodule Peri do
     validate_field(data, schema, source, opts)
   end
 
+  defp validate_field(data, {:schema, schema, schema_opts}, source, opts)
+       when is_list(schema_opts) do
+    validate_field(data, schema, source, opts)
+  end
+
   defp validate_field(
          data,
          {:schema, schema, {:additional_keys, value_schema}},
@@ -1246,7 +1258,7 @@ defmodule Peri do
 
   defp validate_field(data, schema, _data, _opts)
        when is_enumerable(data) and not is_enumerable(schema) do
-    {:error, "expected a nested schema but received schema: %{type}", [type: schema]}
+    {:error, "expected a nested schema but received schema: %{type}", [type: summarize(schema)]}
   end
 
   defp validate_field(data, schema, p, opts) when is_enumerable(data) do
@@ -1267,7 +1279,7 @@ defmodule Peri do
   end
 
   defp validate_field(val, type, _data, _opts) do
-    info = [expected: type, actual: inspect(val, pretty: true)]
+    info = [expected: summarize(type), actual: inspect(val, pretty: true)]
     {:error, "expected type of %{expected} received %{actual} value", info}
   end
 
@@ -1630,7 +1642,7 @@ defmodule Peri do
 
   defp validate_type({:required, {type, {:default, val}}}, _) do
     template = "cannot set default value of %{value} for required field of type %{type}"
-    {:error, template, [value: val, type: type]}
+    {:error, template, [value: val, type: summarize(type)]}
   end
 
   defp validate_type({:meta, type, meta_opts}, p) when is_list(meta_opts) do
@@ -1712,6 +1724,22 @@ defmodule Peri do
   defp validate_type({:schema, type, {:additional_keys, value_type}}, p) when is_map(type) do
     with :ok <- validate_type(type, p) do
       validate_type(value_type, p)
+    end
+  end
+
+  defp validate_type({:schema, type, schema_opts}, p) when is_list(schema_opts) do
+    cond do
+      not Keyword.keyword?(schema_opts) ->
+        {:error, "expected :schema opts to be a keyword list, got %{actual}",
+         actual: inspect(schema_opts)}
+
+      not is_binary(Keyword.get(schema_opts, :name, "")) and
+          not is_atom(Keyword.get(schema_opts, :name)) ->
+        {:error, "expected :schema name to be a binary or atom, got %{actual}",
+         actual: inspect(Keyword.get(schema_opts, :name))}
+
+      true ->
+        validate_type(type, p)
     end
   end
 

--- a/lib/peri/error.ex
+++ b/lib/peri/error.ex
@@ -231,6 +231,102 @@ defmodule Peri.Error do
     %{error | path: new_path ++ path, errors: updated_errors}
   end
 
+  @doc """
+  Produces a compact, human-friendly string for a schema or type definition.
+
+  Used in error messages to avoid dumping the entire schema (which can be huge
+  for deeply nested or polymorphic schemas). Named schemas
+  (`{:schema, _, name: "..."}`) render as their name; raw maps render as a
+  truncated key list (`%{a, b, c, +N more}`).
+  """
+  @spec summarize(term) :: String.t()
+  def summarize(type), do: summarize(type, 3)
+
+  defp summarize(type, _max_keys) when is_atom(type), do: inspect(type)
+
+  defp summarize({:schema, _schema, opts}, _max_keys)
+       when is_list(opts) do
+    case Keyword.fetch(opts, :name) do
+      {:ok, name} when is_binary(name) -> name
+      {:ok, name} -> to_string(name)
+      :error -> summarize_schema_opts({:schema, _schema, opts})
+    end
+  end
+
+  defp summarize({:schema, schema, {:additional_keys, _}}, max_keys) do
+    summarize(schema, max_keys) <> " (+ additional keys)"
+  end
+
+  defp summarize({:schema, schema}, max_keys), do: summarize(schema, max_keys)
+
+  defp summarize({:ref, {mod, name}}, _max_keys) when is_atom(mod) and is_atom(name),
+    do: "#{inspect(mod)}.#{name}"
+
+  defp summarize({:ref, name}, _max_keys), do: "ref(#{inspect(name)})"
+
+  defp summarize({:list, type}, max_keys), do: "{:list, #{summarize(type, max_keys)}}"
+  defp summarize({:map, type}, max_keys), do: "{:map, #{summarize(type, max_keys)}}"
+
+  defp summarize({:map, kt, vt}, max_keys),
+    do: "{:map, #{summarize(kt, max_keys)}, #{summarize(vt, max_keys)}}"
+
+  defp summarize({:tuple, types}, max_keys) when is_list(types),
+    do: "{:tuple, [#{Enum.map_join(types, ", ", &summarize(&1, max_keys))}]}"
+
+  defp summarize({:enum, choices}, _max_keys) when is_list(choices),
+    do: "{:enum, #{inspect(choices)}}"
+
+  defp summarize({:literal, val}, _max_keys), do: "{:literal, #{inspect(val)}}"
+
+  defp summarize({:either, {a, b}}, max_keys),
+    do: "{:either, #{summarize(a, max_keys)} | #{summarize(b, max_keys)}}"
+
+  defp summarize({:oneof, types}, max_keys) when is_list(types),
+    do: "{:oneof, [#{Enum.map_join(types, ", ", &summarize(&1, max_keys))}]}"
+
+  defp summarize({:multi, field, branches}, _max_keys) when is_map(branches) do
+    tags = branches |> Map.keys() |> Enum.map_join(", ", &inspect/1)
+    "{:multi, #{inspect(field)}, [#{tags}]}"
+  end
+
+  defp summarize({:required, type}, max_keys),
+    do: "{:required, #{summarize(type, max_keys)}}"
+
+  defp summarize({:required, type, _opts}, max_keys),
+    do: "{:required, #{summarize(type, max_keys)}}"
+
+  defp summarize({:meta, type, _}, max_keys), do: summarize(type, max_keys)
+
+  defp summarize({type, {:default, _}}, max_keys), do: summarize(type, max_keys)
+
+  defp summarize({type, opts}, max_keys) when is_atom(type) and is_list(opts),
+    do: inspect(type)
+
+  defp summarize(schema, max_keys) when is_map(schema) and not is_struct(schema) do
+    keys = Map.keys(schema)
+    total = length(keys)
+
+    shown =
+      keys
+      |> Enum.take(max_keys)
+      |> Enum.map_join(", ", &format_key/1)
+
+    cond do
+      total == 0 -> "%{}"
+      total <= max_keys -> "%{#{shown}}"
+      true -> "%{#{shown}, +#{total - max_keys} more}"
+    end
+  end
+
+  defp summarize(other, _max_keys),
+    do: inspect(other, limit: 3, printable_limit: 50)
+
+  defp summarize_schema_opts({:schema, schema, _opts}), do: summarize(schema, 3)
+
+  defp format_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp format_key(key) when is_binary(key), do: inspect(key)
+  defp format_key(key), do: inspect(key)
+
   def format_error_message(reason, context) when is_list(context) and is_binary(reason) do
     Enum.reduce(context, reason, fn {key, val}, acc ->
       String.replace(

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,9 @@ defmodule Peri.MixProject do
         "pages/types.md",
         "pages/validation.md",
         "pages/ecto.md",
-        "pages/generation.md"
+        "pages/generation.md",
+        "pages/json_schema.md",
+        "pages/refs.md"
       ],
       groups_for_extras: [
         Guides: ~r/pages\/.*/

--- a/test/peri_test.exs
+++ b/test/peri_test.exs
@@ -69,7 +69,7 @@ defmodule PeriTest do
                  %Peri.Error{
                    path: [:age],
                    key: :age,
-                   content: %{actual: "\"thirty\"", expected: :integer},
+                   content: %{actual: "\"thirty\"", expected: ":integer"},
                    message: "expected type of :integer received \"thirty\" value",
                    errors: nil
                  }
@@ -133,7 +133,7 @@ defmodule PeriTest do
                          %Peri.Error{
                            path: [:user, :profile, :age],
                            key: :age,
-                           content: %{expected: :integer, actual: "\"twenty-five\""},
+                           content: %{expected: ":integer", actual: "\"twenty-five\""},
                            message: "expected type of :integer received \"twenty-five\" value",
                            errors: nil
                          }
@@ -166,7 +166,7 @@ defmodule PeriTest do
                          %Peri.Error{
                            path: [:user, :profile, :email],
                            key: :email,
-                           content: %{expected: :string},
+                           content: %{expected: ":string"},
                            message: "is required, expected type of :string",
                            errors: nil
                          }
@@ -269,7 +269,7 @@ defmodule PeriTest do
                         %Peri.Error{
                           path: [:definitions, :main, :foobar],
                           key: :foobar,
-                          content: %{actual: "\"fifty-five\"", expected: :integer},
+                          content: %{actual: "\"fifty-five\"", expected: ":integer"},
                           message: "expected type of :integer received \"fifty-five\" value",
                           errors: nil
                         }
@@ -299,7 +299,7 @@ defmodule PeriTest do
                  %Peri.Error{
                    path: [:phone],
                    key: :phone,
-                   content: %{actual: "123456", expected: :string},
+                   content: %{actual: "123456", expected: ":string"},
                    message: "expected type of :string received 123456 value",
                    errors: nil
                  }
@@ -334,7 +334,7 @@ defmodule PeriTest do
                  %Peri.Error{
                    path: [:tags],
                    key: :tags,
-                   content: %{actual: "42", expected: :string},
+                   content: %{actual: "42", expected: ":string"},
                    message: "expected type of :string received 42 value",
                    errors: nil
                  }
@@ -357,7 +357,7 @@ defmodule PeriTest do
                  %Peri.Error{
                    path: [:scores],
                    key: :scores,
-                   content: %{actual: "\"twenty\"", expected: :integer},
+                   content: %{actual: "\"twenty\"", expected: ":integer"},
                    message: "expected type of :integer received \"twenty\" value",
                    errors: nil
                  }
@@ -716,7 +716,7 @@ defmodule PeriTest do
                      %Peri.Error{
                        path: [:users, :name],
                        key: :name,
-                       content: %{expected: :string},
+                       content: %{expected: ":string"},
                        message: "is required, expected type of :string",
                        errors: nil
                      }
@@ -742,7 +742,7 @@ defmodule PeriTest do
                      %Peri.Error{
                        path: [:users, :age],
                        key: :age,
-                       content: %{expected: :integer, actual: "\"thirty\""},
+                       content: %{expected: ":integer", actual: "\"thirty\""},
                        message: "expected type of :integer received \"thirty\" value",
                        errors: nil
                      }
@@ -839,7 +839,7 @@ defmodule PeriTest do
                  %Peri.Error{
                    message: "tuple element 1: expected type of :float received \"20.5\" value",
                    path: [:coordinates],
-                   content: %{index: 1, expected: :float, actual: "\"20.5\""},
+                   content: %{index: 1, expected: ":float", actual: "\"20.5\""},
                    errors: nil,
                    key: :coordinates
                  }
@@ -910,7 +910,7 @@ defmodule PeriTest do
                %Peri.Error{
                  path: nil,
                  key: nil,
-                 content: %{expected: :string, actual: "123"},
+                 content: %{expected: ":string", actual: "123"},
                  message: "expected type of :string received 123 value",
                  errors: nil
                }
@@ -937,7 +937,7 @@ defmodule PeriTest do
                      %Peri.Error{
                        path: [:scores, :score],
                        key: :score,
-                       content: %{expected: :float, actual: "\"high\""},
+                       content: %{expected: ":float", actual: "\"high\""},
                        message: "expected type of :float received \"high\" value",
                        errors: nil
                      }
@@ -978,7 +978,7 @@ defmodule PeriTest do
                          %Peri.Error{
                            path: [:children, :children, :id],
                            key: :id,
-                           content: %{expected: :integer, actual: "\"invalid\""},
+                           content: %{expected: ":integer", actual: "\"invalid\""},
                            message: "expected type of :integer received \"invalid\" value",
                            errors: nil
                          }
@@ -999,7 +999,7 @@ defmodule PeriTest do
                  :error,
                  [
                    %Peri.Error{
-                     content: %{expected: :integer},
+                     content: %{expected: ":integer"},
                      errors: nil,
                      key: :id,
                      message: "is required, expected type of :integer",
@@ -1042,7 +1042,7 @@ defmodule PeriTest do
                :error,
                [
                  %Peri.Error{
-                   content: %{expected: :string},
+                   content: %{expected: ":string"},
                    errors: nil,
                    key: :email,
                    message: "is required, expected type of :string",
@@ -1096,7 +1096,7 @@ defmodule PeriTest do
                       %Peri.Error{
                         path: [:user, :email],
                         key: :email,
-                        content: %{expected: :string},
+                        content: %{expected: ":string"},
                         message: "is required, expected type of :string",
                         errors: nil
                       }
@@ -1157,7 +1157,7 @@ defmodule PeriTest do
                  %Peri.Error{
                    path: [:age],
                    key: :age,
-                   content: %{actual: "\"thirty\"", expected: :integer},
+                   content: %{actual: "\"thirty\"", expected: ":integer"},
                    message: "expected type of :integer received \"thirty\" value",
                    errors: nil
                  }
@@ -1193,7 +1193,7 @@ defmodule PeriTest do
                          %Peri.Error{
                            path: [:user, :profile, :age],
                            key: :age,
-                           content: %{expected: :integer, actual: "\"twenty-five\""},
+                           content: %{expected: ":integer", actual: "\"twenty-five\""},
                            message: "expected type of :integer received \"twenty-five\" value",
                            errors: nil
                          }
@@ -1226,7 +1226,7 @@ defmodule PeriTest do
                          %Peri.Error{
                            path: [:user, :profile, :email],
                            key: :email,
-                           content: %{expected: :string},
+                           content: %{expected: ":string"},
                            message: "is required, expected type of :string",
                            errors: nil
                          }
@@ -1259,7 +1259,7 @@ defmodule PeriTest do
                  %Peri.Error{
                    path: [:phone],
                    key: :phone,
-                   content: %{actual: "123456", expected: :string},
+                   content: %{actual: "123456", expected: ":string"},
                    message: "expected type of :string received 123456 value",
                    errors: nil
                  }
@@ -1306,7 +1306,7 @@ defmodule PeriTest do
                      %Peri.Error{
                        path: [:user_info, :username],
                        key: :username,
-                       content: %{expected: :string},
+                       content: %{expected: ":string"},
                        message: "is required, expected type of :string",
                        errors: nil
                      }
@@ -1369,7 +1369,7 @@ defmodule PeriTest do
                          %Peri.Error{
                            path: [:user_info, :avatar, :url],
                            key: :url,
-                           content: %{expected: :string, actual: "12345"},
+                           content: %{expected: ":string", actual: "12345"},
                            message: "expected type of :string received 12345 value",
                            errors: nil
                          }
@@ -1692,7 +1692,7 @@ defmodule PeriTest do
                            path: [:user, :profile, :email],
                            key: :email,
                            content: %{
-                             type: :string,
+                             type: ":string",
                              value: "default@example.com",
                              schema: %{
                                address: %{
@@ -1858,7 +1858,7 @@ defmodule PeriTest do
                  %Peri.Error{
                    path: [:id],
                    key: :id,
-                   content: %{actual: "123", expected: :string},
+                   content: %{actual: "123", expected: ":string"},
                    message: "expected type of :string received 123 value",
                    errors: nil
                  }
@@ -1873,7 +1873,7 @@ defmodule PeriTest do
                 %Peri.Error{
                   path: [:id],
                   key: :id,
-                  content: %{actual: "123", expected: :string},
+                  content: %{actual: "123", expected: ":string"},
                   message: "expected type of :string received 123 value",
                   errors: nil
                 }
@@ -2410,8 +2410,8 @@ defmodule PeriTest do
                  %Peri.Error{
                    path: [:details],
                    key: :details,
-                   content: %{expected: %{email: {:required, :string}}},
-                   message: "is required, expected type of %{email: {:required, :string}}",
+                   content: %{expected: "%{email}"},
+                   message: "is required, expected type of %{email}",
                    errors: nil
                  }
                ]
@@ -2428,8 +2428,8 @@ defmodule PeriTest do
                  %Peri.Error{
                    path: [:details],
                    key: :details,
-                   content: %{expected: %{country: {:required, :string}}},
-                   message: "is required, expected type of %{country: {:required, :string}}",
+                   content: %{expected: "%{country}"},
+                   message: "is required, expected type of %{country}",
                    errors: nil
                  }
                ]
@@ -2517,11 +2517,8 @@ defmodule PeriTest do
                %Peri.Error{
                  path: [:details],
                  key: :details,
-                 content: %{
-                   expected: %{email: {:required, :string}, country: {:required, :string}}
-                 },
-                 message:
-                   "is required, expected type of %{email: {:required, :string}, country: {:required, :string}}",
+                 content: %{expected: "%{email, country}"},
+                 message: "is required, expected type of %{email, country}",
                  errors: nil
                }
              ] = errors
@@ -2546,7 +2543,7 @@ defmodule PeriTest do
                    %Peri.Error{
                      path: [:details, :country],
                      key: :country,
-                     content: %{expected: :string},
+                     content: %{expected: ":string"},
                      message: "is required, expected type of :string",
                      errors: nil
                    }
@@ -2776,9 +2773,8 @@ defmodule PeriTest do
                 %Peri.Error{
                   path: [:profile],
                   key: :profile,
-                  content: %{expected: %{name: {:required, :string}, email: :string}},
-                  message:
-                    "is required, expected type of %{name: {:required, :string}, email: :string}",
+                  content: %{expected: "%{name, email}"},
+                  message: "is required, expected type of %{name, email}",
                   errors: nil
                 }
               ]} = Peri.validate(required, %{id: "123"})
@@ -2805,7 +2801,7 @@ defmodule PeriTest do
                     %Peri.Error{
                       path: [:profile, :name],
                       key: :name,
-                      content: %{expected: :string},
+                      content: %{expected: ":string"},
                       message: "is required, expected type of :string",
                       errors: nil
                     }


### PR DESCRIPTION
## Summary
- Added `Peri.Error.summarize/1` to render types/schemas as compact strings in error messages
- Replaced `inspect` of schemas at validation error sites in `lib/peri.ex` (`:required` missing, `:either`, `:oneof`, `:schema`-mismatch fallback, `validate_field` fallback, `:required` + `:default` conflict)
- Added `{:schema, schema, opts}` keyword form to support `name:` opt for named schema rendering
- Updated test expectations in `test/peri_test.exs` for new content shape (`expected:` is now a summary string, not raw schema map) and shorter messages

Closes the last item from [#44](https://github.com/zoedsoupe/peri/issues/44): no more full-schema dumps in error messages.

### Examples
- Before: `is required, expected type of %{name: {:required, :string}, email: :string}`
- After: `is required, expected type of %{name, email}`

For named schemas:
```elixir
{:schema, %{...big schema...}, name: "User"}
# error renders as: "...expected type of User"
```

## Test plan
- [x] `mix test` — 1 doctest, 399 tests, 0 failures
- [x] `mix credo --strict` — no issues
- [x] `mix format`