### PR TITLE
feat: extend JSON Schema meta vocab to Draft-7 keywords

### DIFF
--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -110,9 +110,12 @@ defmodule Peri do
   ## Schema Metadata
 
   Fields can carry metadata via the `{:meta, type, opts}` wrapper. Metadata is
-  ignored at validation time but available for documentation, JSON Schema export
-  (planned), and tooling. Blessed keys: `:doc`, `:title`, `:description`,
-  `:example`, `:deprecated`. User keys are preserved opaquely.
+  ignored at validation time but available for documentation, JSON Schema
+  export, and tooling. The JSON Schema encoder recognises the standard
+  Draft-7 annotation/format vocabulary (`:title`, `:description`, `:example`,
+  `:examples`, `:deprecated`, `:default`, `:format`, `:pattern`, `:read_only`,
+  `:write_only`, `:content_encoding`, `:content_media_type`); other keys
+  (e.g. `:doc`) are preserved opaquely for non-encoder tooling.
 
   ```elixir
   defschema :user, %{

--- a/lib/peri/json_schema/encoder.ex
+++ b/lib/peri/json_schema/encoder.ex
@@ -3,8 +3,8 @@ defmodule Peri.JSONSchema.Encoder do
   Encodes a Peri schema definition into a JSON Schema (Draft 7) map.
 
   Field-level metadata attached via `{:meta, type, opts}` is read during
-  encoding and surfaced as JSON Schema annotation keywords (`title`,
-  `description`, `examples`, `deprecated`).
+  encoding and surfaced as JSON Schema annotation/format keywords. See
+  `@meta_keys` for the recognised vocabulary; unknown keys are dropped.
 
   Dynamic Peri types (`:dependent`, `:cond`, `:custom`) cannot be expressed
   statically. The `:on_unsupported` option controls the fallback:
@@ -28,7 +28,27 @@ defmodule Peri.JSONSchema.Encoder do
     end
   end
 
-  @meta_keys [:title, :description, :example, :deprecated]
+  @meta_keys [
+    :title,
+    :description,
+    :example,
+    :examples,
+    :deprecated,
+    :default,
+    :format,
+    :pattern,
+    :read_only,
+    :write_only,
+    :content_encoding,
+    :content_media_type
+  ]
+
+  @meta_key_renames %{
+    read_only: "readOnly",
+    write_only: "writeOnly",
+    content_encoding: "contentEncoding",
+    content_media_type: "contentMediaType"
+  }
 
   @spec encode(Peri.schema(), opts) :: map
   def encode(schema, opts \\ []) do
@@ -289,7 +309,11 @@ defmodule Peri.JSONSchema.Encoder do
   end
 
   defp put_meta(schema, :example, value), do: Map.put(schema, "examples", List.wrap(value))
-  defp put_meta(schema, key, value), do: Map.put(schema, Atom.to_string(key), value)
+  defp put_meta(schema, :examples, value), do: Map.put(schema, "examples", List.wrap(value))
+
+  defp put_meta(schema, key, value) do
+    Map.put(schema, Map.get(@meta_key_renames, key, Atom.to_string(key)), value)
+  end
 
   defp required?({:required, _}), do: true
   defp required?({:meta, type, _}), do: required?(type)

--- a/pages/json_schema.md
+++ b/pages/json_schema.md
@@ -29,18 +29,26 @@ Peri.to_json_schema(schema)
 
 ### Metadata
 
-`{:meta, type, opts}` annotations are read during encoding. Blessed keys map to
-JSON Schema annotation keywords:
+`{:meta, type, opts}` annotations are read during encoding. Recognised keys map
+to JSON Schema annotation/format keywords:
 
-| Peri meta key  | JSON Schema key               |
-| -------------- | ----------------------------- |
-| `:title`       | `title`                       |
-| `:description` | `description`                 |
-| `:example`     | `examples` (wrapped in array) |
-| `:deprecated`  | `deprecated`                  |
+| Peri meta key         | JSON Schema key               |
+| --------------------- | ----------------------------- |
+| `:title`              | `title`                       |
+| `:description`        | `description`                 |
+| `:example`            | `examples` (wrapped in array) |
+| `:examples`           | `examples`                    |
+| `:deprecated`         | `deprecated`                  |
+| `:default`            | `default`                     |
+| `:format`             | `format`                      |
+| `:pattern`            | `pattern`                     |
+| `:read_only`          | `readOnly`                    |
+| `:write_only`         | `writeOnly`                   |
+| `:content_encoding`   | `contentEncoding`             |
+| `:content_media_type` | `contentMediaType`            |
 
-Non-blessed user keys are preserved as Peri-side metadata only and are not
-written to the JSON Schema.
+Unknown keys are dropped from the encoded schema (they remain available to
+other tooling that reads `:meta` directly).
 
 ### Type mapping
 

--- a/pages/types.md
+++ b/pages/types.md
@@ -102,7 +102,10 @@ Peri provides a comprehensive set of built-in types for schema validation.
 
 The `{:meta, type, opts}` wrapper attaches documentation/tooling info to a field
 without affecting validation. Blessed keys: `:doc`, `:title`, `:description`,
-`:example`, `:deprecated`. User keys are preserved opaquely.
+`:example`/`:examples`, `:deprecated`. The JSON Schema encoder also recognises
+`:default`, `:format`, `:pattern`, `:read_only`, `:write_only`,
+`:content_encoding`, and `:content_media_type` (see `pages/json_schema.md`).
+User keys are preserved opaquely for non-encoder tooling.
 
 `defschema` accepts schema-level meta opts (any non-validation key), exposed via
 the generated `__schema_meta__/1`:

--- a/test/json_schema_test.exs
+++ b/test/json_schema_test.exs
@@ -133,6 +133,40 @@ defmodule Peri.JSONSchemaTest do
       assert prop["deprecated"] == false
       assert json["required"] == ["email"]
     end
+
+    test "meta :examples (plural) accepts a pre-built list" do
+      schema = %{f: {:meta, :string, examples: ["a", "b"]}}
+      assert Peri.to_json_schema(schema)["properties"]["f"]["examples"] == ["a", "b"]
+    end
+
+    test "meta surfaces JSON Schema vocab keys" do
+      schema = %{
+        token:
+          {:meta, :string,
+           format: "uuid",
+           pattern: "^[0-9a-f-]+$",
+           default: "00000000-0000-0000-0000-000000000000",
+           read_only: true,
+           write_only: false,
+           content_encoding: "base64",
+           content_media_type: "application/jwt"}
+      }
+
+      prop = Peri.to_json_schema(schema)["properties"]["token"]
+      assert prop["format"] == "uuid"
+      assert prop["pattern"] == "^[0-9a-f-]+$"
+      assert prop["default"] == "00000000-0000-0000-0000-000000000000"
+      assert prop["readOnly"] == true
+      assert prop["writeOnly"] == false
+      assert prop["contentEncoding"] == "base64"
+      assert prop["contentMediaType"] == "application/jwt"
+    end
+
+    test "meta drops unknown keys" do
+      schema = %{f: {:meta, :string, fromat: "uuid", custom_internal: 1}}
+      prop = Peri.to_json_schema(schema)["properties"]["f"]
+      assert prop == %{"type" => "string"}
+    end
   end
 
   describe "to_json_schema/2 — :on_unsupported" do


### PR DESCRIPTION
**Description**

The JSON Schema encoder previously whitelisted only `:title`, `:description`, `:example`, and `:deprecated` in `{:meta, type, opts}`, silently dropping every other key. This extends the whitelist to the rest of the Draft-7 annotation/format vocabulary so downstream tooling no longer needs side carriers (e.g. Anubis' `:mcp_field`) to inject standard keywords.

Added keys: `:examples`, `:default`, `:format`, `:pattern`, `:read_only`, `:write_only`, `:content_encoding`, `:content_media_type`. snake_case keys are camelCased on output (`read_only` → `readOnly`, etc.). Unknown keys are still dropped — the whitelist preserves typo safety.

`type` override is intentionally not added; if Peri's type inference is wrong, the inference should be fixed rather than shipping an escape hatch.

**Related Issues**

None.

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

**Checklist**

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**

Tests cover the new vocab surface, `:examples` plural form, and unknown-key drop. Docs updated in `pages/json_schema.md`, `pages/types.md`, and the `Peri` moduledoc.

Release-As: 0.8.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded JSON Schema encoder to support additional metadata fields: `default`, `format`, `pattern`, `read_only`, `write_only`, and content encoding attributes
  * Both `:example` and `:examples` now map to JSON Schema's `examples` field

* **Documentation**
  * Updated documentation to reflect broader metadata field support in JSON Schema encoding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->