### PR TITLE
fix: predictable JSON Schema decoder keys via :keys opt

### DIFF
--- a/lib/peri.ex
+++ b/lib/peri.ex
@@ -477,8 +477,9 @@ defmodule Peri do
   Returns `{:ok, schema}` if the resulting Peri schema is valid, otherwise
   `{:error, errors}`.
   """
-  @spec from_json_schema(map) :: {:ok, schema} | {:error, term}
-  defdelegate from_json_schema(json_schema), to: Peri.JSONSchema.Decoder, as: :decode
+  @spec from_json_schema(map, list(opt)) :: {:ok, schema} | {:error, term}
+        when opt: {:keys, :strings | :atoms | :atoms!}
+  defdelegate from_json_schema(json_schema, opts \\ []), to: Peri.JSONSchema.Decoder, as: :decode
 
   @doc """
   Depth-first rewrite of a schema tree.

--- a/lib/peri/json_schema/decoder.ex
+++ b/lib/peri/json_schema/decoder.ex
@@ -123,7 +123,8 @@ defmodule Peri.JSONSchema.Decoder do
   defp safe_key(key, :strings) when is_binary(key), do: key
 
   defp safe_key(key, opt)
-       when opt in [:atoms, :atoms!] and is_atom(key), do: key
+       when opt in [:atoms, :atoms!] and is_atom(key),
+       do: key
 
   defp safe_key(key, :atoms!) when is_binary(key) do
     String.to_atom(key)

--- a/lib/peri/json_schema/decoder.ex
+++ b/lib/peri/json_schema/decoder.ex
@@ -8,36 +8,43 @@ defmodule Peri.JSONSchema.Decoder do
   Prefer `Peri.from_json_schema/1` as the public entry point.
   """
 
-  @spec decode(map) :: {:ok, Peri.schema()} | {:error, term}
-  def decode(json_schema) when is_map(json_schema) do
+  @spec decode(map, list(opt)) :: {:ok, Peri.schema()} | {:error, term}
+        when opt: {:keys, :strings | :atoms | :atoms!}
+  def decode(json_schema, opts) when is_map(json_schema) do
+    keys = Keyword.get(opts, :keys, :strings)
     Process.put(:peri_json_schema_defs_in, Map.get(json_schema, "$defs", %{}))
 
     try do
-      schema = convert_schema(json_schema)
+      schema = convert_schema(json_schema, keys)
       Peri.validate_schema(schema)
     after
       Process.delete(:peri_json_schema_defs_in)
     end
   end
 
-  defp convert_schema(%{"enum" => values, "type" => type})
+  defp convert_schema(%{"enum" => values, "type" => type}, keys_opts)
        when is_list(values) and is_binary(type) do
-    case decode_primitive(type) do
+    case decode_primitive(type, keys_opts) do
       nil -> {:enum, values}
       base -> {:enum, values, type: base}
     end
   end
 
-  defp convert_schema(%{"type" => "object"} = schema), do: convert_object(schema)
-  defp convert_schema(%{"type" => "array"} = schema), do: convert_array(schema)
-  defp convert_schema(%{"type" => "string"} = schema), do: convert_string(schema)
-  defp convert_schema(%{"type" => "number"} = schema), do: convert_number(schema)
-  defp convert_schema(%{"type" => "integer"} = schema), do: convert_integer(schema)
-  defp convert_schema(%{"type" => "boolean"}), do: :boolean
-  defp convert_schema(%{"type" => "null"}), do: {:literal, nil}
+  defp convert_schema(%{"type" => "object"} = schema, keys_opts),
+    do: convert_object(schema, keys_opts)
 
-  defp convert_schema(%{"type" => types} = schema) when is_list(types) do
-    schemas = Enum.map(types, fn type -> convert_schema(Map.put(schema, "type", type)) end)
+  defp convert_schema(%{"type" => "array"} = schema, keys_opt),
+    do: convert_array(schema, keys_opt)
+
+  defp convert_schema(%{"type" => "string"} = schema, _), do: convert_string(schema)
+  defp convert_schema(%{"type" => "number"} = schema, _), do: convert_number(schema)
+  defp convert_schema(%{"type" => "integer"} = schema, _), do: convert_integer(schema)
+  defp convert_schema(%{"type" => "boolean"}, _), do: :boolean
+  defp convert_schema(%{"type" => "null"}, _), do: {:literal, nil}
+
+  defp convert_schema(%{"type" => types} = schema, keys_opt) when is_list(types) do
+    schemas =
+      Enum.map(types, fn type -> convert_schema(Map.put(schema, "type", type), keys_opt) end)
 
     case schemas do
       [single] -> single
@@ -46,20 +53,20 @@ defmodule Peri.JSONSchema.Decoder do
     end
   end
 
-  defp convert_schema(%{"$ref" => "#/$defs/" <> name}) do
+  defp convert_schema(%{"$ref" => "#/$defs/" <> name}, keys_opt) do
     defs = Process.get(:peri_json_schema_defs_in, %{})
 
     case Map.fetch(defs, name) do
-      {:ok, def_schema} -> convert_schema(def_schema)
+      {:ok, def_schema} -> convert_schema(def_schema, keys_opt)
       :error -> :any
     end
   end
 
-  defp convert_schema(%{"const" => value}), do: {:literal, value}
-  defp convert_schema(%{"enum" => values}) when is_list(values), do: {:enum, values}
+  defp convert_schema(%{"const" => value}, _), do: {:literal, value}
+  defp convert_schema(%{"enum" => values}, _) when is_list(values), do: {:enum, values}
 
-  defp convert_schema(%{"oneOf" => schemas}) when is_list(schemas) do
-    converted = Enum.map(schemas, &convert_schema/1)
+  defp convert_schema(%{"oneOf" => schemas}, keys_opt) when is_list(schemas) do
+    converted = Enum.map(schemas, &convert_schema(&1, keys_opt))
 
     case converted do
       [single] -> single
@@ -72,61 +79,68 @@ defmodule Peri.JSONSchema.Decoder do
   # JSON Schema's `anyOf` semantics. JSON Schema's `oneOf` requires *exactly
   # one* match; Peri cannot express that constraint, so `oneOf` is decoded
   # to `:oneof` lossily (treated as `anyOf`).
-  defp convert_schema(%{"anyOf" => schemas}) when is_list(schemas) do
-    convert_schema(%{"oneOf" => schemas})
+  defp convert_schema(%{"anyOf" => schemas}, keys_opt) when is_list(schemas) do
+    convert_schema(%{"oneOf" => schemas}, keys_opt)
   end
 
-  defp convert_schema(%{"allOf" => schemas}) when is_list(schemas) do
+  defp convert_schema(%{"allOf" => schemas}, keys_opt) when is_list(schemas) do
     Enum.reduce(schemas, %{}, fn schema, acc ->
-      case convert_schema(schema) do
+      case convert_schema(schema, keys_opt) do
         map when is_map(map) -> Map.merge(acc, map)
         _other -> acc
       end
     end)
   end
 
-  defp convert_schema(%{"additionalProperties" => add_props}) when is_map(add_props) do
-    {:map, convert_schema(add_props)}
+  defp convert_schema(%{"additionalProperties" => add_props}, keys_opt) when is_map(add_props) do
+    {:map, convert_schema(add_props, keys_opt)}
   end
 
-  defp convert_schema(_), do: :any
+  defp convert_schema(_, _), do: :any
 
-  defp decode_primitive("string"), do: :string
-  defp decode_primitive("integer"), do: :integer
-  defp decode_primitive("number"), do: :float
-  defp decode_primitive("boolean"), do: :boolean
-  defp decode_primitive(_), do: nil
+  defp decode_primitive("string", _), do: :string
+  defp decode_primitive("integer", _), do: :integer
+  defp decode_primitive("number", _), do: :float
+  defp decode_primitive("boolean", _), do: :boolean
+  defp decode_primitive(_, _), do: nil
 
-  defp convert_object(%{"properties" => properties} = schema) do
+  defp convert_object(%{"properties" => properties} = schema, keys_opt) do
     required = Map.get(schema, "required", [])
 
     Map.new(properties, fn {key, prop_schema} ->
-      peri_type = convert_schema(prop_schema)
+      peri_type = convert_schema(prop_schema, keys_opt)
       final = if key in required, do: {:required, peri_type}, else: peri_type
-      {safe_key(key), final}
+      {safe_key(key, keys_opt), final}
     end)
   end
 
-  defp convert_object(%{"additionalProperties" => add_props}) when is_map(add_props) do
-    {:map, convert_schema(add_props)}
+  defp convert_object(%{"additionalProperties" => add_props}, keys_opt) when is_map(add_props) do
+    {:map, convert_schema(add_props, keys_opt)}
   end
 
-  defp convert_object(_), do: %{}
+  defp convert_object(_, _), do: %{}
 
-  defp safe_key(key) when is_atom(key), do: key
+  defp safe_key(key, :strings) when is_binary(key), do: key
 
-  defp safe_key(key) when is_binary(key) do
+  defp safe_key(key, opt)
+       when opt in [:atoms, :atoms!] and is_atom(key), do: key
+
+  defp safe_key(key, :atoms!) when is_binary(key) do
+    String.to_atom(key)
+  end
+
+  defp safe_key(key, :atoms) when is_binary(key) do
     String.to_existing_atom(key)
   rescue
     ArgumentError -> key
   end
 
-  defp convert_array(%{"items" => items} = schema) do
-    base = {:list, convert_schema(items)}
+  defp convert_array(%{"items" => items} = schema, keys_opt) do
+    base = {:list, convert_schema(items, keys_opt)}
     apply_list_constraints(base, schema)
   end
 
-  defp convert_array(schema) do
+  defp convert_array(schema, _) do
     apply_list_constraints({:list, :any}, schema)
   end
 

--- a/test/json_schema_test.exs
+++ b/test/json_schema_test.exs
@@ -196,8 +196,8 @@ defmodule Peri.JSONSchemaTest do
       }
 
       assert {:ok, schema} = Peri.from_json_schema(json)
-      assert schema[:name] == {:required, :string}
-      assert schema[:age] == :integer
+      assert schema["name"] == {:required, :string}
+      assert schema["age"] == :integer
     end
 
     test "primitives" do
@@ -240,16 +240,147 @@ defmodule Peri.JSONSchemaTest do
       assert {:ok, :string} = Peri.from_json_schema(json)
     end
 
-    test "non-existing atom keys fall back to string keys" do
-      key = "this_atom_does_not_exist_#{System.unique_integer([:positive])}"
+    test "default :keys opt yields string keys regardless of atom-table state" do
+      missing = "missing_atom_#{System.unique_integer([:positive])}"
 
       json = %{
         "type" => "object",
-        "properties" => %{key => %{"type" => "string"}}
+        "properties" => %{
+          "name" => %{"type" => "string"},
+          missing => %{"type" => "integer"}
+        }
       }
 
       assert {:ok, schema} = Peri.from_json_schema(json)
-      assert schema[key] == :string
+      assert schema["name"] == :string
+      assert schema[missing] == :integer
+      assert Enum.all?(Map.keys(schema), &is_binary/1)
+    end
+  end
+
+  describe "from_json_schema/2 — :keys option" do
+    test ":strings (explicit) keeps all keys as binaries" do
+      json = %{
+        "type" => "object",
+        "properties" => %{"name" => %{"type" => "string"}, "age" => %{"type" => "integer"}},
+        "required" => ["name"]
+      }
+
+      assert {:ok, schema} = Peri.from_json_schema(json, keys: :strings)
+      assert schema["name"] == {:required, :string}
+      assert schema["age"] == :integer
+    end
+
+    test ":atoms uses existing atoms" do
+      json = %{
+        "type" => "object",
+        "properties" => %{
+          "name" => %{"type" => "string"},
+          "age" => %{"type" => "integer"}
+        },
+        "required" => ["name"]
+      }
+
+      assert {:ok, schema} = Peri.from_json_schema(json, keys: :atoms)
+      assert schema[:name] == {:required, :string}
+      assert schema[:age] == :integer
+    end
+
+    test ":atoms falls back to string when atom does not exist" do
+      missing = "peri_test_missing_atom_#{System.unique_integer([:positive])}"
+
+      json = %{
+        "type" => "object",
+        "properties" => %{missing => %{"type" => "string"}}
+      }
+
+      assert {:ok, schema} = Peri.from_json_schema(json, keys: :atoms)
+      assert schema[missing] == :string
+    end
+
+    test ":atoms! force-creates atoms for every key" do
+      missing_1 = "peri_test_atoms_bang_1_#{System.unique_integer([:positive])}"
+      missing_2 = "peri_test_atoms_bang_2_#{System.unique_integer([:positive])}"
+
+      json = %{
+        "type" => "object",
+        "properties" => %{
+          missing_1 => %{"type" => "string"},
+          missing_2 => %{"type" => "integer"}
+        },
+        "required" => [missing_1]
+      }
+
+      assert {:ok, schema} = Peri.from_json_schema(json, keys: :atoms!)
+      assert schema[String.to_atom(missing_1)] == {:required, :string}
+      assert schema[String.to_atom(missing_2)] == :integer
+      assert Enum.all?(Map.keys(schema), &is_atom/1)
+    end
+
+    test "opt propagates into nested objects" do
+      json = %{
+        "type" => "object",
+        "properties" => %{
+          "outer" => %{
+            "type" => "object",
+            "properties" => %{"inner" => %{"type" => "string"}}
+          }
+        }
+      }
+
+      assert {:ok, %{outer: %{inner: :string}}} = Peri.from_json_schema(json, keys: :atoms)
+    end
+
+    test "opt propagates into oneOf branches that are objects" do
+      json = %{
+        "oneOf" => [
+          %{"type" => "object", "properties" => %{"name" => %{"type" => "string"}}},
+          %{"type" => "integer"}
+        ]
+      }
+
+      assert {:ok, {:either, {%{name: :string}, :integer}}} =
+               Peri.from_json_schema(json, keys: :atoms)
+    end
+
+    test "opt propagates into array items that are objects" do
+      json = %{
+        "type" => "array",
+        "items" => %{"type" => "object", "properties" => %{"name" => %{"type" => "string"}}}
+      }
+
+      assert {:ok, {:list, %{name: :string}}} = Peri.from_json_schema(json, keys: :atoms)
+    end
+
+    test "opt propagates into $ref resolution" do
+      json = %{
+        "$defs" => %{
+          "Item" => %{"type" => "object", "properties" => %{"name" => %{"type" => "string"}}}
+        },
+        "type" => "object",
+        "properties" => %{"item" => %{"$ref" => "#/$defs/Item"}}
+      }
+
+      assert {:ok, %{item: %{name: :string}}} = Peri.from_json_schema(json, keys: :atoms)
+    end
+
+    test "opt propagates into allOf merged objects" do
+      json = %{
+        "allOf" => [
+          %{"type" => "object", "properties" => %{"a" => %{"type" => "string"}}},
+          %{"type" => "object", "properties" => %{"b" => %{"type" => "integer"}}}
+        ]
+      }
+
+      assert {:ok, %{a: :string, b: :integer}} = Peri.from_json_schema(json, keys: :atoms)
+    end
+
+    test "unknown :keys value raises FunctionClauseError" do
+      json = %{"type" => "object", "properties" => %{"x" => %{"type" => "string"}}}
+
+      assert_raise FunctionClauseError, fn ->
+        Peri.from_json_schema(json, keys: :bogus)
+      end
     end
   end
 
@@ -264,8 +395,8 @@ defmodule Peri.JSONSchemaTest do
       schema = %{name: {:required, :string}, age: :integer}
       json = Peri.to_json_schema(schema)
       assert {:ok, decoded} = Peri.from_json_schema(json)
-      assert decoded[:name] == {:required, :string}
-      assert decoded[:age] == :integer
+      assert decoded["name"] == {:required, :string}
+      assert decoded["age"] == :integer
     end
 
     test "list of strings" do
@@ -276,6 +407,21 @@ defmodule Peri.JSONSchemaTest do
     test "integer with gte" do
       assert {:ok, {:integer, {:gte, 0}}} =
                {:integer, gte: 0} |> Peri.to_json_schema() |> Peri.from_json_schema()
+    end
+
+    test "object with atom keys recovered via keys: :atoms" do
+      schema = %{name: {:required, :string}, age: :integer}
+      json = Peri.to_json_schema(schema)
+
+      assert {:ok, ^schema} = Peri.from_json_schema(json, keys: :atoms)
+    end
+
+    test "object with unknown atom keys recovered via keys: :atoms!" do
+      key = String.to_atom("peri_rt_atoms_bang_#{System.unique_integer([:positive])}")
+      schema = %{key => {:required, :string}}
+      json = Peri.to_json_schema(schema)
+
+      assert {:ok, ^schema} = Peri.from_json_schema(json, keys: :atoms!)
     end
   end
 


### PR DESCRIPTION
**Description**
`Peri.from_json_schema/2` now accepts `keys: :strings | :atoms | :atoms!`. Default `:strings` produces predictable string keys instead of relying on atom-table state. `:atoms` keeps prior behavior (existing atom or fall back to string). `:atoms!` force-creates atoms.

**Related Issues**
Closes #64.

**Type of Change**

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

**Checklist**

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
Breaking: prior default returned mixed atom/string keys depending on atom table. Existing callers wanting old behavior pass `keys: :atoms`.