### PR TITLE
fix: decode JSON Schema number/integer to either int|float per spec

### DIFF
--- a/lib/peri/json_schema/decoder.ex
+++ b/lib/peri/json_schema/decoder.ex
@@ -191,17 +191,14 @@ defmodule Peri.JSONSchema.Decoder do
     end)
   end
 
-  defp convert_number(schema) do
-    :float
-    |> apply_constraint(schema, "minimum", :gte)
-    |> apply_constraint(schema, "maximum", :lte)
-    |> apply_constraint(schema, "exclusiveMinimum", :gt)
-    |> apply_constraint(schema, "exclusiveMaximum", :lt)
-    |> apply_constraint(schema, "multipleOf", :multiple_of)
-  end
+  defp convert_number(schema),
+    do: {:either, {apply_numeric(:integer, schema), apply_numeric(:float, schema)}}
 
-  defp convert_integer(schema) do
-    :integer
+  defp convert_integer(schema),
+    do: {:either, {apply_numeric(:integer, schema), apply_numeric(:float, schema)}}
+
+  defp apply_numeric(base, schema) do
+    base
     |> apply_constraint(schema, "minimum", :gte)
     |> apply_constraint(schema, "maximum", :lte)
     |> apply_constraint(schema, "exclusiveMinimum", :gt)

--- a/test/json_schema_test.exs
+++ b/test/json_schema_test.exs
@@ -197,14 +197,21 @@ defmodule Peri.JSONSchemaTest do
 
       assert {:ok, schema} = Peri.from_json_schema(json)
       assert schema["name"] == {:required, :string}
-      assert schema["age"] == :integer
+      assert schema["age"] == {:either, {:integer, :float}}
     end
 
     test "primitives" do
       assert {:ok, :string} = Peri.from_json_schema(%{"type" => "string"})
-      assert {:ok, :integer} = Peri.from_json_schema(%{"type" => "integer"})
       assert {:ok, :boolean} = Peri.from_json_schema(%{"type" => "boolean"})
       assert {:ok, {:literal, nil}} = Peri.from_json_schema(%{"type" => "null"})
+    end
+
+    test "numeric primitives map to either int|float per JSON Schema spec" do
+      assert {:ok, {:either, {:integer, :float}}} =
+               Peri.from_json_schema(%{"type" => "integer"})
+
+      assert {:ok, {:either, {:integer, :float}}} =
+               Peri.from_json_schema(%{"type" => "number"})
     end
 
     test "const → literal" do
@@ -221,13 +228,43 @@ defmodule Peri.JSONSchemaTest do
     end
 
     test "oneOf with two → either" do
-      json = %{"oneOf" => [%{"type" => "string"}, %{"type" => "integer"}]}
-      assert {:ok, {:either, {:string, :integer}}} = Peri.from_json_schema(json)
+      json = %{"oneOf" => [%{"type" => "string"}, %{"type" => "boolean"}]}
+      assert {:ok, {:either, {:string, :boolean}}} = Peri.from_json_schema(json)
     end
 
-    test "integer minimum → gte" do
+    test "integer minimum → gte applied to both branches" do
       json = %{"type" => "integer", "minimum" => 0}
-      assert {:ok, {:integer, {:gte, 0}}} = Peri.from_json_schema(json)
+
+      assert {:ok, {:either, {{:integer, {:gte, 0}}, {:float, {:gte, 0}}}}} =
+               Peri.from_json_schema(json)
+    end
+
+    test "number minimum → gte applied to both branches" do
+      json = %{"type" => "number", "minimum" => 0}
+
+      assert {:ok, {:either, {{:integer, {:gte, 0}}, {:float, {:gte, 0}}}}} =
+               Peri.from_json_schema(json)
+    end
+
+    test "decoded number schema validates both ints and floats (issue #65)" do
+      {:ok, schema} = Peri.from_json_schema(%{"type" => "number"})
+      assert {:ok, 5} = Peri.validate(schema, 5)
+      assert {:ok, 5.5} = Peri.validate(schema, 5.5)
+      assert {:error, _} = Peri.validate(schema, "x")
+    end
+
+    test "decoded integer schema also accepts zero-fractional floats per spec" do
+      {:ok, schema} = Peri.from_json_schema(%{"type" => "integer"})
+      assert {:ok, 5} = Peri.validate(schema, 5)
+      assert {:ok, 5.0} = Peri.validate(schema, 5.0)
+    end
+
+    test "decoded constrained number applies bounds to both ints and floats" do
+      {:ok, schema} = Peri.from_json_schema(%{"type" => "number", "minimum" => 0})
+      assert {:ok, 0} = Peri.validate(schema, 0)
+      assert {:ok, 0.5} = Peri.validate(schema, 0.5)
+      assert {:error, _} = Peri.validate(schema, -1)
+      assert {:error, _} = Peri.validate(schema, -0.5)
     end
 
     test "string pattern → regex" do
@@ -253,7 +290,7 @@ defmodule Peri.JSONSchemaTest do
 
       assert {:ok, schema} = Peri.from_json_schema(json)
       assert schema["name"] == :string
-      assert schema[missing] == :integer
+      assert schema[missing] == {:either, {:integer, :float}}
       assert Enum.all?(Map.keys(schema), &is_binary/1)
     end
   end
@@ -268,7 +305,7 @@ defmodule Peri.JSONSchemaTest do
 
       assert {:ok, schema} = Peri.from_json_schema(json, keys: :strings)
       assert schema["name"] == {:required, :string}
-      assert schema["age"] == :integer
+      assert schema["age"] == {:either, {:integer, :float}}
     end
 
     test ":atoms uses existing atoms" do
@@ -283,7 +320,7 @@ defmodule Peri.JSONSchemaTest do
 
       assert {:ok, schema} = Peri.from_json_schema(json, keys: :atoms)
       assert schema[:name] == {:required, :string}
-      assert schema[:age] == :integer
+      assert schema[:age] == {:either, {:integer, :float}}
     end
 
     test ":atoms falls back to string when atom does not exist" do
@@ -313,7 +350,7 @@ defmodule Peri.JSONSchemaTest do
 
       assert {:ok, schema} = Peri.from_json_schema(json, keys: :atoms!)
       assert schema[String.to_atom(missing_1)] == {:required, :string}
-      assert schema[String.to_atom(missing_2)] == :integer
+      assert schema[String.to_atom(missing_2)] == {:either, {:integer, :float}}
       assert Enum.all?(Map.keys(schema), &is_atom/1)
     end
 
@@ -335,11 +372,11 @@ defmodule Peri.JSONSchemaTest do
       json = %{
         "oneOf" => [
           %{"type" => "object", "properties" => %{"name" => %{"type" => "string"}}},
-          %{"type" => "integer"}
+          %{"type" => "boolean"}
         ]
       }
 
-      assert {:ok, {:either, {%{name: :string}, :integer}}} =
+      assert {:ok, {:either, {%{name: :string}, :boolean}}} =
                Peri.from_json_schema(json, keys: :atoms)
     end
 
@@ -372,7 +409,8 @@ defmodule Peri.JSONSchemaTest do
         ]
       }
 
-      assert {:ok, %{a: :string, b: :integer}} = Peri.from_json_schema(json, keys: :atoms)
+      assert {:ok, %{a: :string, b: {:either, {:integer, :float}}}} =
+               Peri.from_json_schema(json, keys: :atoms)
     end
 
     test "unknown :keys value raises FunctionClauseError" do
@@ -385,9 +423,16 @@ defmodule Peri.JSONSchemaTest do
   end
 
   describe "round-trip" do
-    test "primitives" do
-      for type <- [:string, :integer, :float, :boolean] do
+    test "primitives (string, boolean) round-trip exactly" do
+      for type <- [:string, :boolean] do
         assert {:ok, ^type} = type |> Peri.to_json_schema() |> Peri.from_json_schema()
+      end
+    end
+
+    test "numeric primitives widen to either int|float on decode (lossy by spec)" do
+      for type <- [:integer, :float] do
+        assert {:ok, {:either, {:integer, :float}}} =
+                 type |> Peri.to_json_schema() |> Peri.from_json_schema()
       end
     end
 
@@ -396,7 +441,7 @@ defmodule Peri.JSONSchemaTest do
       json = Peri.to_json_schema(schema)
       assert {:ok, decoded} = Peri.from_json_schema(json)
       assert decoded["name"] == {:required, :string}
-      assert decoded["age"] == :integer
+      assert decoded["age"] == {:either, {:integer, :float}}
     end
 
     test "list of strings" do
@@ -404,8 +449,8 @@ defmodule Peri.JSONSchemaTest do
                {:list, :string} |> Peri.to_json_schema() |> Peri.from_json_schema()
     end
 
-    test "integer with gte" do
-      assert {:ok, {:integer, {:gte, 0}}} =
+    test "integer with gte widens to either with constraint on both branches" do
+      assert {:ok, {:either, {{:integer, {:gte, 0}}, {:float, {:gte, 0}}}}} =
                {:integer, gte: 0} |> Peri.to_json_schema() |> Peri.from_json_schema()
     end
 
@@ -413,7 +458,9 @@ defmodule Peri.JSONSchemaTest do
       schema = %{name: {:required, :string}, age: :integer}
       json = Peri.to_json_schema(schema)
 
-      assert {:ok, ^schema} = Peri.from_json_schema(json, keys: :atoms)
+      assert {:ok, decoded} = Peri.from_json_schema(json, keys: :atoms)
+      assert decoded[:name] == {:required, :string}
+      assert decoded[:age] == {:either, {:integer, :float}}
     end
 
     test "object with unknown atom keys recovered via keys: :atoms!" do

--- a/test/list_constraints_test.exs
+++ b/test/list_constraints_test.exs
@@ -114,29 +114,34 @@ defmodule Peri.ListConstraintsTest do
       assert opts[:unique] == true
     end
 
-    test "decodes multipleOf for integer" do
+    test "decodes multipleOf for integer (widens to either int|float per spec)" do
       json = %{"type" => "integer", "multipleOf" => 5}
-      assert {:ok, {:integer, {:multiple_of, 5}}} = Peri.from_json_schema(json)
+
+      assert {:ok, {:either, {{:integer, {:multiple_of, 5}}, {:float, {:multiple_of, 5}}}}} =
+               Peri.from_json_schema(json)
     end
 
-    test "plain array still decodes to {:list, t}" do
+    test "plain array decodes integer items as either int|float" do
       json = %{"type" => "array", "items" => %{"type" => "integer"}}
-      assert {:ok, {:list, :integer}} = Peri.from_json_schema(json)
+      assert {:ok, {:list, {:either, {:integer, :float}}}} = Peri.from_json_schema(json)
     end
   end
 
   describe "roundtrip" do
-    test "list constraints roundtrip" do
+    test "list constraints roundtrip (numeric items widen to either)" do
       peri = {:list, :integer, [min: 1, max: 3, unique: true]}
       json = Peri.to_json_schema(peri)
-      assert {:ok, decoded} = Peri.from_json_schema(json)
-      assert decoded == peri
+
+      assert {:ok, {:list, {:either, {:integer, :float}}, [min: 1, max: 3, unique: true]}} =
+               Peri.from_json_schema(json)
     end
 
-    test "multiple_of roundtrip" do
+    test "multiple_of roundtrip widens to either int|float" do
       peri = {:integer, {:multiple_of, 5}}
       json = Peri.to_json_schema(peri)
-      assert {:ok, ^peri} = Peri.from_json_schema(json)
+
+      assert {:ok, {:either, {{:integer, {:multiple_of, 5}}, {:float, {:multiple_of, 5}}}}} =
+               Peri.from_json_schema(json)
     end
   end
 


### PR DESCRIPTION
**Description**
JSON Schema spec defines \`number\` as int OR float and \`integer\` as a number with zero fractional part. Decoder previously mapped both to single Peri types (\`:float\`, \`:integer\`), rejecting valid payloads (e.g. \`5\` against \`number\`, \`5.0\` against \`integer\`). Both now decode to \`{:either, {:integer, :float}}\` with constraints applied to each branch.

**Related Issues**
Closes #65.

**Type of Change**

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

**Checklist**

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

**Additional Context**
Breaking: \`Peri.from_json_schema/2\` on numeric types no longer round-trips to the exact source Peri schema. Decoded shape is wider (\`{:either, {:integer, :float}}\`) but matches JSON Schema semantics.