### PR TITLE
fix: error_to_map nil content handling

### DIFF
--- a/lib/peri/error.ex
+++ b/lib/peri/error.ex
@@ -390,15 +390,32 @@ defmodule Peri.Error do
     }
   end
 
-  defp transform_content(content) do
-    for {k, v} <- content do
-      if is_tuple(v) do
-        {k, transform_tuple(v)}
-      else
-        {k, v}
-      end
-    end
+  defp transform_content(nil), do: nil
+
+  defp transform_content(content) when is_map(content) do
+    content
+    |> Enum.map(&transform_content_entry/1)
     |> Map.new()
+  end
+
+  defp transform_content(content) when is_list(content) do
+    if Enum.all?(content, &match?({_, _}, &1)) do
+      content
+      |> Enum.map(&transform_content_entry/1)
+      |> Map.new()
+    else
+      content
+    end
+  end
+
+  defp transform_content(content), do: content
+
+  defp transform_content_entry({k, v}) do
+    if is_tuple(v) do
+      {k, transform_tuple(v)}
+    else
+      {k, v}
+    end
   end
 
   defp transform_tuple(tuple) when is_tuple(tuple) do

--- a/test/custom_errors_test.exs
+++ b/test/custom_errors_test.exs
@@ -103,4 +103,65 @@ defmodule Peri.CustomErrorsTest do
       assert Enum.all?(translated, fn err -> err.message == "ok" end)
     end
   end
+
+  describe "Peri.Error.error_to_map/1" do
+    test "keeps nil content without raising" do
+      error = %Peri.Error{
+        message: "Expected type string, got integer",
+        content: nil,
+        path: [:user, :age],
+        key: :age,
+        errors: nil
+      }
+
+      assert %{
+               message: "Expected type string, got integer",
+               content: nil,
+               path: [:user, :age],
+               key: :age,
+               errors: nil
+             } = Peri.Error.error_to_map(error)
+    end
+
+    test "keeps nil content in nested errors without raising" do
+      error = %Peri.Error{
+        message: "Validation failed",
+        content: %{expected: :string, actual: :integer},
+        path: [:user, :age],
+        key: :age,
+        errors: [
+          %Peri.Error{
+            message: "Expected type string, got integer",
+            content: nil,
+            path: [:user, :age],
+            key: :age,
+            errors: nil
+          }
+        ]
+      }
+
+      assert %{
+               content: %{expected: :string, actual: :integer},
+               errors: [
+                 %{
+                   message: "Expected type string, got integer",
+                   content: nil,
+                   path: [:user, :age],
+                   key: :age,
+                   errors: nil
+                 }
+               ]
+             } = Peri.Error.error_to_map(error)
+    end
+
+    test "still transforms tuple content inside map and keyword content" do
+      map_error = %Peri.Error{content: %{schema: {:list, {:tuple, [:string, :integer]}}}}
+      keyword_error = %Peri.Error{content: [schema: {:list, :string}]}
+
+      assert %{content: %{schema: [:list, [:tuple, [:string, :integer]]]}} =
+               Peri.Error.error_to_map(map_error)
+
+      assert %{content: %{schema: [:list, :string]}} = Peri.Error.error_to_map(keyword_error)
+    end
+  end
 end

--- a/test/custom_errors_test.exs
+++ b/test/custom_errors_test.exs
@@ -163,5 +163,11 @@ defmodule Peri.CustomErrorsTest do
 
       assert %{content: %{schema: [:list, :string]}} = Peri.Error.error_to_map(keyword_error)
     end
+
+    test "keeps non-keyword list content unchanged" do
+      error = %Peri.Error{content: [1, 2, 3]}
+
+      assert %{content: [1, 2, 3]} = Peri.Error.error_to_map(error)
+    end
   end
 end


### PR DESCRIPTION
## Description

Make `Peri.Error.error_to_map/1` tolerate `content: nil` instead of raising `Protocol.UndefinedError` while preserving existing tuple normalization behavior for map and keyword content.

This came up through downstream MCP error logging: a nested `%Peri.Error{content: nil}` can mask the original validation/tool error by crashing while serializing the error. The module docs already include a nested error with `content: nil`, so `error_to_map/1` should handle that shape.

## Related Issues

- Downstream context: https://github.com/agentjido/jido_mcp/issues/15

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] Breaking change
- [ ] Documentation only

## Checklist

- [x] Added regression coverage for root `content: nil`
- [x] Added regression coverage for nested `content: nil`
- [x] Added regression coverage for tuple normalization in map/keyword content
- [x] Added regression coverage for non-keyword list passthrough
- [x] Ran `git diff --check`
- [ ] Ran `mix test test/custom_errors_test.exs` (not available here because `mix` is not installed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * More robust error conversion: preserves nil, handles maps, detects and converts keyword-like tuple lists, and leaves non-keyword lists unchanged.
* **Tests**
  * Added tests covering nil and nested error content, keyword-like tuple/list conversion, and non-keyword list preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zoedsoupe/peri/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->